### PR TITLE
[ALS-4617] Performance improvements for GIC

### DIFF
--- a/client-api/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/Query.java
+++ b/client-api/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/query/Query.java
@@ -4,8 +4,12 @@ import java.util.*;
 
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.Filter.DoubleFilter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.Filter.FloatFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Query {
+
+	private static final Logger log = LoggerFactory.getLogger(Query.class);
 
 	public Query() {
 
@@ -180,7 +184,7 @@ public class Query {
 			break;
 		default:
 			//no logic here; all enum values should be present above
-			System.out.println("Formatting not supported for type " + expectedResultType);
+			log.warn("Formatting not supported for type {}", expectedResultType);
 		}
 
 		writePartFormat("Required Fields", requiredFields, builder, false);

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/AbstractProcessor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/AbstractProcessor.java
@@ -627,7 +627,7 @@ public class AbstractProcessor {
 										inStream.close();
 										return ret;
 									}else {
-										System.out.println("ColumnMeta not found for : [" + key + "]");
+										log.warn("ColumnMeta not found for : [{}]", key);
 										return null;
 									}
 								}


### PR DESCRIPTION
- Made QueryProcessor filter columns that DNE
- Paralellized QueryProcessor::runQuery
- Switch `sout` logging to standard slf4j logging
  - Faster
  - No blocking threads due to synchronized methods