### PR TITLE
[ALS-5656] Make TimeSeriesProcessor handle missing concept paths

### DIFF
--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/AbstractProcessor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/AbstractProcessor.java
@@ -667,6 +667,19 @@ public class AbstractProcessor {
 		}
 	}
 
+	/**
+	 * Get a cube without throwing an error if not found.
+	 * Useful for federated pic-sure's where there are fewer
+	 * guarantees about concept paths.
+	 */
+	protected Optional<PhenoCube<?>> nullableGetCube(String path) {
+		try {
+			return Optional.ofNullable(store.get(path));
+		} catch (InvalidCacheLoadException | ExecutionException e) {
+			return Optional.empty();
+		}
+	}
+
 	public TreeMap<String, ColumnMeta> getDictionary() {
 		return phenotypeMetaStore.getMetaStore();
 	}

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/TimeseriesProcessor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/TimeseriesProcessor.java
@@ -103,11 +103,12 @@ public class TimeseriesProcessor implements HpdsProcessor {
 				continue;
 			}
 			ArrayList<String[]> dataEntries = new ArrayList<String[]>();
-			PhenoCube<?> cube = abstractProcessor.getCube(conceptPath);
-			if(cube == null) {
-				log.warn("Attempting export of non-existant concept: " + conceptPath);
+			Optional<PhenoCube<?>> maybeCube = abstractProcessor.nullableGetCube(conceptPath);
+			if(maybeCube.isEmpty()) {
+				log.warn("Attempting export of non-existant concept: {}", conceptPath);
 				continue;
 			}
+			PhenoCube<?> cube = maybeCube.get();
 			log.debug("Exporting " + conceptPath);
 			List<?> valuesForKeys = cube.getValuesForKeys(idList);
 			for (Object kvObj : valuesForKeys) {


### PR DESCRIPTION
- In GIC land, we get queries that have a concept path that is present in some other site, but not the one the query is getting run in
- The TimeseriesProcessor needs to not explode when this happens