### PR TITLE
[ALS-0000] Quick fix to time series. Use different batch size

### DIFF
--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/TimeseriesProcessor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/TimeseriesProcessor.java
@@ -126,7 +126,7 @@ public class TimeseriesProcessor implements HpdsProcessor {
 					dataEntries.add(entryData);
 				}
 				//batch exports so we don't take double memory (valuesForKeys + dataEntries could be a lot of data points)
-				if(dataEntries.size() >= ID_BATCH_SIZE) {
+				if(dataEntries.size() >= (ID_BATCH_SIZE > 0 ? 10 : ID_BATCH_SIZE)) {
 					result.stream.appendResults(dataEntries);
 					dataEntries = new ArrayList<String[]>();
 				}


### PR DESCRIPTION
If we reduce the batch size, normal GIC queries take ages. If we don't, timeseries queries go OOM. 