### PR TITLE
Fix export headers

### DIFF
--- a/service/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/service/QueryService.java
+++ b/service/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/service/QueryService.java
@@ -119,11 +119,12 @@ public class QueryService {
 		default : 
 			throw new RuntimeException("UNSUPPORTED RESULT TYPE");
 		}
-		
+
+		queryDecorator.setId(query);
 		AsyncResult result = new AsyncResult(query, p.getHeaderRow(query));
 		result.status = AsyncResult.Status.PENDING;
 		result.queuedTime = System.currentTimeMillis();
-		queryDecorator.setId(query);
+
 		result.id = query.getId();
 		result.processor = p;
 		results.put(result.id, result);


### PR DESCRIPTION
Fix export headers. `mergeFilterFieldsIntoSelectedFields` must be executed before the new AsyncResult