### PR TITLE
[CHORE] NPEs for timestamps

### DIFF
--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/timeseries/TimeSeriesConversionService.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/timeseries/TimeSeriesConversionService.java
@@ -9,6 +9,9 @@ import java.time.format.DateTimeFormatter;
 public class TimeSeriesConversionService {
 
     public String toISOString(Long unixTimeStamp) {
+        if (unixTimeStamp == null) {
+            return "";
+        }
         Instant instant = Instant.ofEpochMilli(unixTimeStamp);
         return DateTimeFormatter.ISO_INSTANT.format(instant);
     }


### PR DESCRIPTION
```
29-Aug-2024 13:15:26.197 SEVERE [pool-3-thread-1] edu.harvard.hms.dbmi.avillach.hpds.processing.AsyncResult.run Query failed in 1966444ms
	java.lang.NullPointerException
		at edu.harvard.hms.dbmi.avillach.hpds.processing.timeseries.TimeSeriesConversionService.toISOString(TimeSeriesConversionService.java:12)
		at edu.harvard.hms.dbmi.avillach.hpds.processing.timeseries.TimeseriesProcessor.addDataForConcepts(TimeseriesProcessor.java:131)
		at edu.harvard.hms.dbmi.avillach.hpds.processing.timeseries.TimeseriesProcessor.exportTimeData(TimeseriesProcessor.java:104)
		at edu.harvard.hms.dbmi.avillach.hpds.processing.timeseries.TimeseriesProcessor.runQuery(TimeseriesProcessor.java:74)
		at edu.harvard.hms.dbmi.avillach.hpds.processing.AsyncResult.run(AsyncResult.java:110)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
		at java.base/java.lang.Thread.run(Unknown Source)
```