### PR TITLE
Fix npe, this functionality should be deprecated but we needed it for…

### DIFF
--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/GenomicProcessorNoOp.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/GenomicProcessorNoOp.java
@@ -46,16 +46,16 @@ public class GenomicProcessorNoOp implements GenomicProcessor {
 
     @Override
     public Set<String> getInfoStoreColumns() {
-        return null;
+        return Set.of();
     }
 
     @Override
     public Set<String> getInfoStoreValues(String conceptPath) {
-        return null;
+        return Set.of();
     }
 
     @Override
     public List<InfoColumnMeta> getInfoColumnMeta() {
-        return null;
+        return List.of();
     }
 }


### PR DESCRIPTION
… the adapters backwards compatibility here:

https://github.com/hms-dbmi/pic-sure-hpds/blob/acf11472318b6b0c4d2e4201a6cce415e9a6cea4/service/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/service/PicSureService.java#L154