### PR TITLE
ALS-9008: Update storage directory for BucketIndexBySample on load

### DIFF
--- a/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/genotype/BucketIndexBySample.java
+++ b/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/genotype/BucketIndexBySample.java
@@ -189,4 +189,8 @@ public class BucketIndexBySample implements Serializable {
 		}
 		return _emptyBucketMaskChar.clone();
 	}
+
+	public void updateStorageDirectory(File storageDirectory) {
+		patientBucketMasks.updateStorageDirectory(storageDirectory);
+	}
 }

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/VariantService.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/VariantService.java
@@ -181,6 +181,7 @@ public class VariantService {
                 try (ObjectInputStream objectInputStream = new ObjectInputStream(new GZIPInputStream(new FileInputStream(BUCKET_INDEX_BY_SAMPLE_FILE)));){
                     log.info("loading " + BUCKET_INDEX_BY_SAMPLE_FILE);
                     bucketIndex = (BucketIndexBySample) objectInputStream.readObject();
+                    bucketIndex.updateStorageDirectory(new File(genomicDataDirectory));
                 } catch (IOException | ClassNotFoundException e) {
                     log.error("an error occurred", e);
                 }


### PR DESCRIPTION
We found and cleaned up similar issues elsewhere in the codebase on BDC, but BDC does not use the variant explorer and we missed this. This only happens when the bucket index file is built as part of the ETL process, because the directory it is built in is not the directory it ends up in for a running HPDS instance.