### PR TITLE
[ALS-9114] getValuesForKeys did not work with unsorted sets

### DIFF
--- a/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/PhenoCube.java
+++ b/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/PhenoCube.java
@@ -218,6 +218,8 @@ public class PhenoCube<V extends Comparable<V>> implements Serializable {
 	}
 
 	public List<KeyAndValue<V>> getValuesForKeys(Set<Integer> patientIds) {
+		patientIds = new TreeSet<>(patientIds);
+
 		List<KeyAndValue<V>> values = new ArrayList<>();
 		int x = 0;
 		for(Integer id : patientIds) {

--- a/data/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/PhenoCubeTest.java
+++ b/data/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/PhenoCubeTest.java
@@ -1,0 +1,29 @@
+package edu.harvard.hms.dbmi.avillach.hpds.data.phenotype;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+class PhenoCubeTest {
+
+    @Test
+    void shouldGetValuesForKeys() {
+        KeyAndValue[] sortedByKey = {
+            new KeyAndValue<>(1, "a"),
+            new KeyAndValue<>(1, "b"),
+            new KeyAndValue<>(2, "c"),
+            new KeyAndValue<>(3, "d"),
+        };
+        PhenoCube<String> subject = new PhenoCube<>("phill the phenocube", String.class);
+        subject.setSortedByKey(sortedByKey);
+
+        Set<Integer> patientIds = new LinkedHashSet<>(List.of(3, 2, 1));
+        List<KeyAndValue<String>> actual = subject.getValuesForKeys(patientIds);
+        List<KeyAndValue<String>> expected = List.of(sortedByKey);
+
+        Assertions.assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
- It expected sets to be sorted
- Could skip valid entries if patientIds were out of order