### PR TITLE
Add validation for DATETIME in CSVLoaderNewSearch

### DIFF
--- a/etl/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/CSVLoaderNewSearch.java
+++ b/etl/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/CSVLoaderNewSearch.java
@@ -132,7 +132,7 @@ public class CSVLoaderNewSearch {
                 );
 
                 Date date = null;
-                if (record.size() > 4) {
+                if (record.size() > 4 && !record.get(DATETIME).equals("0")) {
                     date = parseUtcDatetimeOrNull(record.get(DATETIME), record);
                 }
 


### PR DESCRIPTION
- Ensure DATETIME is not "0" before parsing.
- Prevent non-time series data from defaulting to epoch date times