### PR TITLE
Require authorization filter by default

### DIFF
--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidator.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidator.java
@@ -24,7 +24,7 @@ public class QueryValidator {
     @Autowired
     public QueryValidator(
         PhenotypicQueryExecutor phenotypicQueryExecutor, PhenotypicFilterValidator phenotypicFilterValidator,
-        @Value("${hpds.requireAuthorizationFilter:false}") boolean requireAuthorizationFilter
+        @Value("${hpds.requireAuthorizationFilter:true}") boolean requireAuthorizationFilter
     ) {
         this.phenotypicQueryExecutor = phenotypicQueryExecutor;
         this.phenotypicFilterValidator = phenotypicFilterValidator;

--- a/service/src/main/resources/application-integration-test.properties
+++ b/service/src/main/resources/application-integration-test.properties
@@ -9,3 +9,4 @@ HPDS_GENOMIC_DATA_DIRECTORY=target/all/
 HPDS_DATA_DIRECTORY=target/test-classes/phenotypic/
 
 enable_file_sharing=false
+hpds.requireAuthorizationFilter=false

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -8,3 +8,7 @@ logging.file.name=/var/log/hpds.log
 logging.level.root=info
 log.pattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z', UTC} %-5level --- [hpds] [%thread] %logger{36} : %msg%n
 enable_file_sharing=false
+
+# This should only be set to true if you wish to control patient data access granularly
+# See edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query.authorizationFilters for more information
+# hpds.requireAuthorizationFilter=false


### PR DESCRIPTION
This might be a bit of an annoyance in non-auth environments, but I think this should be true by default. Anyone wishing to run completely open queries should have to specify this parameter as false