### PR TITLE
[ALS-11895] Fix v3 cross counts: merge duplicate filters and report over the whole cohort

### DIFF
--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
@@ -148,14 +148,19 @@ public class CountV3Processor implements HpdsV3Processor {
     }
 
     /**
-     * A categorical cross count is produced for value filters and REQUIRED filters, excluding variant-spec paths which are not phenotypic
-     * categories.
+     * A categorical cross count is produced for value filters and for REQUIRED filters on categorical concepts, excluding variant-spec
+     * paths. A REQUIRED filter on a continuous concept is gated out here (it is handled by {@link #runContinuousCrossCounts}); otherwise it
+     * would be admitted and rely on the cube having no category map to avoid emitting a meaningless empty entry.
      */
     private boolean isCategoryCrossCountFilter(PhenotypicFilter filter) {
         if (VariantUtils.pathIsVariantSpec(filter.conceptPath())) {
             return false;
         }
-        return filter.isCategoricalFilter() || PhenotypicFilterType.REQUIRED.equals(filter.phenotypicFilterType());
+        if (filter.isCategoricalFilter()) {
+            return true;
+        }
+        return PhenotypicFilterType.REQUIRED.equals(filter.phenotypicFilterType())
+            && Optional.ofNullable(queryExecutor.getDictionary().get(filter.conceptPath())).map(meta -> meta.isCategorical()).orElse(false);
     }
 
     /**

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Note: This class was copied from {@link edu.harvard.hms.dbmi.avillach.hpds.processing.CountProcessor} and updated to use new Query entity
@@ -105,66 +106,54 @@ public class CountV3Processor implements HpdsV3Processor {
 
     /**
      * Returns a separate count for each field in the requiredFields and categoryFilters query.
+     * <p>
+     * The v3 query lets a user add multiple filters on the same variable (e.g. sex=male OR sex=female). Filters are grouped by concept path
+     * so each variable produces exactly one entry rather than later filters overwriting earlier ones. When a path carries any REQUIRED
+     * filter, the full category distribution is reported; otherwise only the values named by its value filters are reported. The two are
+     * unioned, so a REQUIRED + value filter on the same path yields the full distribution.
      *
      * @param query
      * @return a map of categorical data and their counts
      */
     public Map<String, Map<String, Integer>> runCategoryCrossCounts(Query query) {
-        Map<String, Map<String, Integer>> categoryCounts = new TreeMap<>();
         Set<Integer> baseQueryPatientSet = queryExecutor.getPatientSubsetForQuery(query);
-        query.allFilters().parallelStream()
-            .filter(phenotypicFilter -> PhenotypicFilterType.REQUIRED.equals(phenotypicFilter.phenotypicFilterType()))
-            .map(PhenotypicFilter::conceptPath).forEach(concept -> {
-                Map<String, Integer> varCount = new TreeMap<>();;
-                TreeMap<String, TreeSet<Integer>> categoryMap = (TreeMap<String, TreeSet<Integer>>) phenotypicObservationStore
-                    .getCube(concept).map(PhenoCube::getCategoryMap).orElseGet(TreeMap::new);
-                // We do not have all the categories (aka variables) for required fields, so we need to get them and
-                // then ensure that our base patient set, which is filtered down by our filters. Which may include
-                // not only other required filters, but categorical filters, numerical filters, or genomic filters.
-                // We then need to get the amount a patients for each category and map that to the concept path.
-                categoryMap.forEach((String category, TreeSet<Integer> patientSet) -> {
-                    // If all the patients are in the base then no need to loop, this would always be true for single
-                    // filter queries.
-                    if (baseQueryPatientSet.containsAll(patientSet)) {
-                        varCount.put(category, patientSet.size());
-                    } else {
-                        for (Integer patient : patientSet) {
-                            if (baseQueryPatientSet.contains(patient)) {
-                                // If we have a patient in the base set, we add 1 to the count.
-                                // We are only worried about patients in the base set
-                                varCount.put(category, varCount.getOrDefault(category, 1) + 1);
-                            } else {
-                                // If we don't have a patient in the base set, we add 0 to the count.
-                                // This is necessary because we need to ensure that all categories are included in the
-                                // map, even if they have a count of 0. This is because we are displaying the counts
-                                // in a table (or other form).
-                                varCount.put(category, varCount.getOrDefault(category, 0));
-                            }
-                        }
-                    }
-                });
-                categoryCounts.put(concept, varCount);
-            });
-        // For categoryFilters we need to ensure the variables included in the filter are the ones included in our count
-        // map. Then we make sure that the patients who have that variable are also in our base set.
-        // query.getCategoryFilters().entrySet().parallelStream().forEach(categoryFilterEntry-> {
-        query.allFilters().parallelStream().filter(PhenotypicFilter::isCategoricalFilter).forEach(categoryFilter -> {
-            // Variant spec filter should not be included in cross count map
-            if (VariantUtils.pathIsVariantSpec(categoryFilter.conceptPath())) {
-                return;
-            }
-            Map<String, Integer> varCount;
+
+        Map<String, List<PhenotypicFilter>> filtersByConcept = query.allFilters().stream()
+            .filter(this::isCategoryCrossCountFilter).collect(Collectors.groupingBy(PhenotypicFilter::conceptPath));
+
+        Map<String, Map<String, Integer>> categoryCounts = new TreeMap<>();
+        for (Map.Entry<String, List<PhenotypicFilter>> entry : filtersByConcept.entrySet()) {
+            String conceptPath = entry.getKey();
+            List<PhenotypicFilter> filters = entry.getValue();
+
             TreeMap<String, TreeSet<Integer>> categoryMap = (TreeMap<String, TreeSet<Integer>>) phenotypicObservationStore
-                .getCube(categoryFilter.conceptPath()).map(PhenoCube::getCategoryMap).orElseGet(TreeMap::new);
-            varCount = new TreeMap<>();
+                .getCube(conceptPath).map(PhenoCube::getCategoryMap).orElseGet(TreeMap::new);
+
+            boolean includeAllCategories = filters.stream()
+                .anyMatch(filter -> PhenotypicFilterType.REQUIRED.equals(filter.phenotypicFilterType()));
+            Set<String> selectedValues = filters.stream().filter(PhenotypicFilter::isCategoricalFilter)
+                .flatMap(filter -> filter.values().stream()).collect(Collectors.toSet());
+
+            Map<String, Integer> varCount = new TreeMap<>();
             categoryMap.forEach((String category, TreeSet<Integer> patientSet) -> {
-                if (categoryFilter.values().contains(category)) {
+                if (includeAllCategories || selectedValues.contains(category)) {
                     varCount.put(category, Sets.intersection(patientSet, baseQueryPatientSet).size());
                 }
             });
-            categoryCounts.put(categoryFilter.conceptPath(), varCount);
-        });
+            categoryCounts.put(conceptPath, varCount);
+        }
         return categoryCounts;
+    }
+
+    /**
+     * A categorical cross count is produced for value filters and REQUIRED filters, excluding variant-spec paths which are not phenotypic
+     * categories.
+     */
+    private boolean isCategoryCrossCountFilter(PhenotypicFilter filter) {
+        if (VariantUtils.pathIsVariantSpec(filter.conceptPath())) {
+            return false;
+        }
+        return filter.isCategoricalFilter() || PhenotypicFilterType.REQUIRED.equals(filter.phenotypicFilterType());
     }
 
     /**
@@ -174,25 +163,33 @@ public class CountV3Processor implements HpdsV3Processor {
      * @return a map of numerical data and their counts
      */
     public Map<String, Map<Double, Integer>> runContinuousCrossCounts(Query query) {
-        TreeMap<String, Map<Double, Integer>> conceptMap = new TreeMap<>();
         Set<Integer> baseQueryPatientSet = queryExecutor.getPatientSubsetForQuery(query);
-        query.allFilters().parallelStream().filter(this::isContinuousCrossCountFilter).forEach(numericFilter -> {
-            KeyAndValue<Double>[] pairs = phenotypicObservationStore.getCube(numericFilter.conceptPath()).map(phenoCube -> {
-                return ((PhenoCube<Double>) phenoCube).getEntriesForValueRange(numericFilter.min(), numericFilter.max());
-            }).orElseGet(() -> new KeyAndValue[] {});
-            Map<Double, Integer> countMap = new TreeMap<>();
-            Arrays.stream(pairs).forEach(patientConceptPair -> {
-                // The key of the patientConceptPair is the patient id. We need to make sure the patient matches our query.
-                if (baseQueryPatientSet.contains(patientConceptPair.getKey())) {
-                    if (countMap.containsKey(patientConceptPair.getValue())) {
-                        countMap.put((double) patientConceptPair.getValue(), countMap.get(patientConceptPair.getValue()) + 1);
-                    } else {
-                        countMap.put((double) patientConceptPair.getValue(), 1);
+
+        Map<String, List<PhenotypicFilter>> filtersByConcept = query.allFilters().stream()
+            .filter(this::isContinuousCrossCountFilter).collect(Collectors.groupingBy(PhenotypicFilter::conceptPath));
+
+        Map<String, Map<Double, Integer>> conceptMap = new TreeMap<>();
+        for (Map.Entry<String, List<PhenotypicFilter>> entry : filtersByConcept.entrySet()) {
+            String conceptPath = entry.getKey();
+
+            // Multiple range filters on the same variable (e.g. age 0-18 OR age 65+) union their ranges into a single entry. We collect the
+            // observed value per matching patient first so a patient whose value falls in two overlapping ranges is still counted once.
+            Map<Integer, Double> valueByPatient = new HashMap<>();
+            for (PhenotypicFilter numericFilter : entry.getValue()) {
+                KeyAndValue<Double>[] pairs = phenotypicObservationStore.getCube(conceptPath).map(phenoCube -> {
+                    return ((PhenoCube<Double>) phenoCube).getEntriesForValueRange(numericFilter.min(), numericFilter.max());
+                }).orElseGet(() -> new KeyAndValue[] {});
+                for (KeyAndValue<Double> patientConceptPair : pairs) {
+                    if (baseQueryPatientSet.contains(patientConceptPair.getKey())) {
+                        valueByPatient.put(patientConceptPair.getKey(), patientConceptPair.getValue());
                     }
                 }
-            });
-            conceptMap.put(numericFilter.conceptPath(), countMap);
-        });
+            }
+
+            Map<Double, Integer> countMap = new TreeMap<>();
+            valueByPatient.values().forEach(value -> countMap.merge(value, 1, Integer::sum));
+            conceptMap.put(conceptPath, countMap);
+        }
         return conceptMap;
     }
 

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
@@ -108,9 +108,13 @@ public class CountV3Processor implements HpdsV3Processor {
      * Returns a separate count for each field in the requiredFields and categoryFilters query.
      * <p>
      * The v3 query lets a user add multiple filters on the same variable (e.g. sex=male OR sex=female). Filters are grouped by concept path
-     * so each variable produces exactly one entry rather than later filters overwriting earlier ones. When a path carries any REQUIRED
-     * filter, the full category distribution is reported; otherwise only the values named by its value filters are reported. The two are
-     * unioned, so a REQUIRED + value filter on the same path yields the full distribution.
+     * so each variable produces exactly one entry rather than later filters overwriting earlier ones.
+     * <p>
+     * A cross count reports each concept's distribution across the cohort. A category is included when it has members in the cohort, OR when
+     * it was explicitly named ("called out") by a value filter. This means a value filter never hides cohort members that arrived via an OR
+     * branch on another concept (sex=male OR age-required still shows females that have an age), while a value the user specifically asked
+     * for is always shown even when its cohort count is zero. Categories that are neither called out nor present in the cohort are omitted,
+     * so AND-narrowed concepts do not sprout empty bars.
      *
      * @param query
      * @return a map of categorical data and their counts
@@ -124,20 +128,18 @@ public class CountV3Processor implements HpdsV3Processor {
         Map<String, Map<String, Integer>> categoryCounts = new TreeMap<>();
         for (Map.Entry<String, List<PhenotypicFilter>> entry : filtersByConcept.entrySet()) {
             String conceptPath = entry.getKey();
-            List<PhenotypicFilter> filters = entry.getValue();
 
             TreeMap<String, TreeSet<Integer>> categoryMap = (TreeMap<String, TreeSet<Integer>>) phenotypicObservationStore
                 .getCube(conceptPath).map(PhenoCube::getCategoryMap).orElseGet(TreeMap::new);
 
-            boolean includeAllCategories = filters.stream()
-                .anyMatch(filter -> PhenotypicFilterType.REQUIRED.equals(filter.phenotypicFilterType()));
-            Set<String> selectedValues = filters.stream().filter(PhenotypicFilter::isCategoricalFilter)
+            Set<String> calledOutValues = entry.getValue().stream().filter(PhenotypicFilter::isCategoricalFilter)
                 .flatMap(filter -> filter.values().stream()).collect(Collectors.toSet());
 
             Map<String, Integer> varCount = new TreeMap<>();
             categoryMap.forEach((String category, TreeSet<Integer> patientSet) -> {
-                if (includeAllCategories || selectedValues.contains(category)) {
-                    varCount.put(category, Sets.intersection(patientSet, baseQueryPatientSet).size());
+                int count = Sets.intersection(patientSet, baseQueryPatientSet).size();
+                if (count > 0 || calledOutValues.contains(category)) {
+                    varCount.put(category, count);
                 }
             });
             categoryCounts.put(conceptPath, varCount);
@@ -157,7 +159,12 @@ public class CountV3Processor implements HpdsV3Processor {
     }
 
     /**
-     * Returns a separate count for each range in numericFilters in query.
+     * Returns the distribution of observed values for each continuous concept in the query.
+     * <p>
+     * A continuous concept reports the distribution of every observed value across the cohort. Each filter's min/max only constrains the
+     * cohort (handled by the query executor); it does not limit which values are shown. So a range filter never hides cohort members that
+     * arrived via an OR branch on another concept (age&gt;50 OR sex=male still shows the younger ages of the OR'd males), and multiple range
+     * filters on the same concept collapse to one entry since every patient is counted once from the cube.
      *
      * @param query
      * @return a map of numerical data and their counts
@@ -165,29 +172,20 @@ public class CountV3Processor implements HpdsV3Processor {
     public Map<String, Map<Double, Integer>> runContinuousCrossCounts(Query query) {
         Set<Integer> baseQueryPatientSet = queryExecutor.getPatientSubsetForQuery(query);
 
-        Map<String, List<PhenotypicFilter>> filtersByConcept = query.allFilters().stream()
-            .filter(this::isContinuousCrossCountFilter).collect(Collectors.groupingBy(PhenotypicFilter::conceptPath));
+        Set<String> conceptPaths = query.allFilters().stream().filter(this::isContinuousCrossCountFilter)
+            .map(PhenotypicFilter::conceptPath).collect(Collectors.toCollection(LinkedHashSet::new));
 
         Map<String, Map<Double, Integer>> conceptMap = new TreeMap<>();
-        for (Map.Entry<String, List<PhenotypicFilter>> entry : filtersByConcept.entrySet()) {
-            String conceptPath = entry.getKey();
-
-            // Multiple range filters on the same variable (e.g. age 0-18 OR age 65+) union their ranges into a single entry. We collect the
-            // observed value per matching patient first so a patient whose value falls in two overlapping ranges is still counted once.
-            Map<Integer, Double> valueByPatient = new HashMap<>();
-            for (PhenotypicFilter numericFilter : entry.getValue()) {
-                KeyAndValue<Double>[] pairs = phenotypicObservationStore.getCube(conceptPath).map(phenoCube -> {
-                    return ((PhenoCube<Double>) phenoCube).getEntriesForValueRange(numericFilter.min(), numericFilter.max());
-                }).orElseGet(() -> new KeyAndValue[] {});
-                for (KeyAndValue<Double> patientConceptPair : pairs) {
-                    if (baseQueryPatientSet.contains(patientConceptPair.getKey())) {
-                        valueByPatient.put(patientConceptPair.getKey(), patientConceptPair.getValue());
-                    }
+        for (String conceptPath : conceptPaths) {
+            KeyAndValue<Double>[] pairs = phenotypicObservationStore.getCube(conceptPath)
+                .map(phenoCube -> ((PhenoCube<Double>) phenoCube).getEntriesForValueRange(null, null))
+                .orElseGet(() -> new KeyAndValue[] {});
+            Map<Double, Integer> countMap = new TreeMap<>();
+            for (KeyAndValue<Double> patientConceptPair : pairs) {
+                if (baseQueryPatientSet.contains(patientConceptPair.getKey())) {
+                    countMap.merge((double) patientConceptPair.getValue(), 1, Integer::sum);
                 }
             }
-
-            Map<Double, Integer> countMap = new TreeMap<>();
-            valueByPatient.values().forEach(value -> countMap.merge(value, 1, Integer::sum));
             conceptMap.put(conceptPath, countMap);
         }
         return conceptMap;

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
@@ -4,8 +4,10 @@ import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.KeyAndValue;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.PhenoCube;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.ResultType;
+import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Operator;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicFilter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicFilterType;
+import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicSubquery;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -155,5 +160,79 @@ class CountV3ProcessorTest {
 
         assertEquals(1, crossCounts.get(conceptPath).get(18.0));
         assertEquals(1, crossCounts.get(conceptPath).get(19.0));
+    }
+
+    @Test
+    public void runCategoryCrossCounts_duplicateValueFiltersSamePath_mergesValues() {
+        String sexPath = "\\demographics\\SEX\\";
+        PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
+        PhenotypicFilter femaleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("female"), null, null, null);
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, femaleFilter), Operator.OR);
+        Query query = new Query(List.of(), List.of(), subquery, List.of(), ResultType.CATEGORICAL_CROSS_COUNT, null, null);
+
+        TreeMap<String, TreeSet<Integer>> categoryMap = new TreeMap<>();
+        categoryMap.put("male", new TreeSet<>(Set.of(1, 2, 3)));
+        categoryMap.put("female", new TreeSet<>(Set.of(4, 5)));
+        PhenoCube<String> cube = new PhenoCube<>(sexPath, String.class);
+        cube.setCategoryMap(categoryMap);
+
+        when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 2, 3, 4, 5));
+        when(phenotypicObservationStore.getCube(sexPath)).thenReturn(Optional.of(cube));
+
+        Map<String, Map<String, Integer>> crossCounts = countV3Processor.runCategoryCrossCounts(query);
+
+        // Both filter values land in a single SEX entry instead of one overwriting the other
+        assertEquals(1, crossCounts.size());
+        assertEquals(Set.of("male", "female"), crossCounts.get(sexPath).keySet());
+        assertEquals(3, crossCounts.get(sexPath).get("male"));
+        assertEquals(2, crossCounts.get(sexPath).get("female"));
+    }
+
+    @Test
+    public void runCategoryCrossCounts_requiredFilterPartialBaseSet_countsEachPatientOnce() {
+        String sexPath = "\\demographics\\SEX\\";
+        PhenotypicFilter requiredSex = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, sexPath, null, null, null, null);
+        Query query = new Query(List.of(), List.of(), requiredSex, List.of(), ResultType.CATEGORICAL_CROSS_COUNT, null, null);
+
+        TreeMap<String, TreeSet<Integer>> categoryMap = new TreeMap<>();
+        categoryMap.put("male", new TreeSet<>(Set.of(1, 2, 3)));
+        categoryMap.put("female", new TreeSet<>(Set.of(4, 5)));
+        PhenoCube<String> cube = new PhenoCube<>(sexPath, String.class);
+        cube.setCategoryMap(categoryMap);
+
+        // Base set is a partial subset of every category, forcing the per-patient counting path.
+        // Only patient 1 (male) and patient 4 (female) are in the cohort, so each category count must be exactly 1.
+        when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 4));
+        when(phenotypicObservationStore.getCube(sexPath)).thenReturn(Optional.of(cube));
+
+        Map<String, Map<String, Integer>> crossCounts = countV3Processor.runCategoryCrossCounts(query);
+
+        assertEquals(1, crossCounts.get(sexPath).get("male"));
+        assertEquals(1, crossCounts.get(sexPath).get("female"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void runContinuousCrossCounts_duplicateRangesSamePath_mergesRanges() {
+        String agePath = "\\demographics\\AGE\\";
+        PhenotypicFilter youngFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 10.0, 20.0, null);
+        PhenotypicFilter oldFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 60.0, 70.0, null);
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(youngFilter, oldFilter), Operator.OR);
+        Query query = new Query(List.of(), List.of(), subquery, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
+
+        PhenoCube<Double> cube = new PhenoCube<>(agePath, Double.class);
+        cube.setSortedByKey(new KeyAndValue[] {new KeyAndValue<>(1, 15.0), new KeyAndValue<>(2, 40.0), new KeyAndValue<>(3, 65.0)});
+
+        when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 2, 3));
+        when(queryExecutor.getDictionary()).thenReturn(Map.of(agePath, new ColumnMeta().setName(agePath).setCategorical(false)));
+        when(phenotypicObservationStore.getCube(agePath)).thenReturn(Optional.of(cube));
+
+        Map<String, Map<Double, Integer>> crossCounts = countV3Processor.runContinuousCrossCounts(query);
+
+        assertEquals(1, crossCounts.size());
+        assertEquals(1, crossCounts.get(agePath).get(15.0));
+        assertEquals(1, crossCounts.get(agePath).get(65.0));
+        // 40.0 sits in the gap between the two ranges and must not be counted (union of ranges, not a widened span)
+        assertNull(crossCounts.get(agePath).get(40.0));
     }
 }

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
@@ -203,6 +203,7 @@ class CountV3ProcessorTest {
         // Base set is a partial subset of every category, forcing the per-patient counting path.
         // Only patient 1 (male) and patient 4 (female) are in the cohort, so each category count must be exactly 1.
         when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 4));
+        when(queryExecutor.getDictionary()).thenReturn(Map.of(sexPath, new ColumnMeta().setName(sexPath).setCategorical(true)));
         when(phenotypicObservationStore.getCube(sexPath)).thenReturn(Optional.of(cube));
 
         Map<String, Map<String, Integer>> crossCounts = countV3Processor.runCategoryCrossCounts(query);

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
@@ -213,26 +213,26 @@ class CountV3ProcessorTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void runContinuousCrossCounts_duplicateRangesSamePath_mergesRanges() {
+    public void runContinuousCrossCounts_showsCohortValuesOutsideFilterRange() {
         String agePath = "\\demographics\\AGE\\";
+        // A range filter (age 10-20); the cohort, however, includes patient 2 (age 40) who is outside that range -- as happens when the
+        // range is OR'd with a filter on another concept. The age distribution must include 40 because patient 2 is in the cohort; the
+        // filter range only constrains the cohort, not which values are displayed.
         PhenotypicFilter youngFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 10.0, 20.0, null);
-        PhenotypicFilter oldFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 60.0, 70.0, null);
-        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(youngFilter, oldFilter), Operator.OR);
-        Query query = new Query(List.of(), List.of(), subquery, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
+        Query query = new Query(List.of(), List.of(), youngFilter, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
 
         PhenoCube<Double> cube = new PhenoCube<>(agePath, Double.class);
         cube.setSortedByKey(new KeyAndValue[] {new KeyAndValue<>(1, 15.0), new KeyAndValue<>(2, 40.0), new KeyAndValue<>(3, 65.0)});
 
-        when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 2, 3));
+        when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 2));
         when(queryExecutor.getDictionary()).thenReturn(Map.of(agePath, new ColumnMeta().setName(agePath).setCategorical(false)));
         when(phenotypicObservationStore.getCube(agePath)).thenReturn(Optional.of(cube));
 
         Map<String, Map<Double, Integer>> crossCounts = countV3Processor.runContinuousCrossCounts(query);
 
-        assertEquals(1, crossCounts.size());
         assertEquals(1, crossCounts.get(agePath).get(15.0));
-        assertEquals(1, crossCounts.get(agePath).get(65.0));
-        // 40.0 sits in the gap between the two ranges and must not be counted (union of ranges, not a widened span)
-        assertNull(crossCounts.get(agePath).get(40.0));
+        assertEquals(1, crossCounts.get(agePath).get(40.0));
+        // patient 3 (65) is not in the cohort, so it is absent
+        assertNull(crossCounts.get(agePath).get(65.0));
     }
 }

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @EnableAutoConfiguration
@@ -156,6 +158,90 @@ public class CountV3ProcessorIntegrationTest {
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
         assertEquals(1, crossCounts.size());
         assertEquals(2, crossCounts.get("\\open_access-1000Genomes\\data\\SEX\\").get("male"));
+    }
+
+    /**
+     * Two categorical filters on the SAME concept path, OR'd together. With the v3 query a user can add sex=male OR sex=female as two
+     * separate filters; the result must be a SINGLE chart entry for SEX that contains BOTH values, not just the last filter's value.
+     */
+    @Test
+    public void runCategoryCrossCounts_duplicateCategoricalSamePathOr() {
+        String sexPath = "\\open_access-1000Genomes\\data\\SEX\\";
+        PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
+        PhenotypicFilter femaleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("female"), null, null, null);
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, femaleFilter), Operator.OR);
+        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+
+        Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
+
+        assertEquals(1, crossCounts.size());
+        Map<String, Integer> sexCounts = crossCounts.get(sexPath);
+        assertEquals(Set.of("male", "female"), sexCounts.keySet());
+        assertEquals(2648, sexCounts.get("male"));
+        assertEquals(2330, sexCounts.get("female"));
+    }
+
+    /**
+     * Two categorical filters on the same path, AND'd with disjoint values (sex=male AND sex=female) yields an empty cohort. The single SEX
+     * entry must still list both values, each at zero, rather than dropping one to a map-key collision.
+     */
+    @Test
+    public void runCategoryCrossCounts_duplicateCategoricalSamePathAndDisjoint() {
+        String sexPath = "\\open_access-1000Genomes\\data\\SEX\\";
+        PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
+        PhenotypicFilter femaleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("female"), null, null, null);
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, femaleFilter), Operator.AND);
+        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+
+        Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
+
+        assertEquals(1, crossCounts.size());
+        Map<String, Integer> sexCounts = crossCounts.get(sexPath);
+        assertEquals(Set.of("male", "female"), sexCounts.keySet());
+        assertEquals(0, sexCounts.get("male"));
+        assertEquals(0, sexCounts.get("female"));
+    }
+
+    /**
+     * A REQUIRED filter and a value filter on the same path union to the full distribution within the (male-only) cohort: female must be
+     * present at zero rather than dropped by the value filter overwriting the REQUIRED entry.
+     */
+    @Test
+    public void runCategoryCrossCounts_requiredPlusFilterSamePath() {
+        String sexPath = "\\open_access-1000Genomes\\data\\SEX\\";
+        PhenotypicFilter requiredSex = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, sexPath, null, null, null, null);
+        PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(requiredSex, maleFilter), Operator.AND);
+        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+
+        Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
+
+        assertEquals(1, crossCounts.size());
+        Map<String, Integer> sexCounts = crossCounts.get(sexPath);
+        assertEquals(Set.of("male", "female"), sexCounts.keySet());
+        assertEquals(2648, sexCounts.get("male"));
+        assertEquals(0, sexCounts.get("female"));
+    }
+
+    /**
+     * Two numeric range filters on the same path, OR'd, must produce a single entry whose keys are the UNION of the two ranges, not a
+     * widened [min,max] span: a value sitting in the gap between the ranges must NOT appear.
+     */
+    @Test
+    public void runContinuousCrossCounts_duplicateRangesSamePathOr() {
+        String agePath = "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\";
+        PhenotypicFilter youngFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 31.0, 35.0, null);
+        PhenotypicFilter oldFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 55.0, 62.0, null);
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(youngFilter, oldFilter), Operator.OR);
+        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+
+        Map<String, Map<Double, Integer>> crossCounts = countProcessor.runContinuousCrossCounts(query);
+
+        assertEquals(1, crossCounts.size());
+        Map<Double, Integer> ageCounts = crossCounts.get(agePath);
+        assertTrue(ageCounts.containsKey(31.0), "low range endpoint should be present");
+        assertTrue(ageCounts.containsKey(62.0), "high range endpoint should be present");
+        assertFalse(ageCounts.containsKey(44.0), "a value in the gap between the two ranges must not appear");
     }
 
 }

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
@@ -251,6 +251,21 @@ public class CountV3ProcessorIntegrationTest {
     }
 
     /**
+     * A REQUIRED filter on a continuous concept must not produce a categorical cross-count entry: continuous concepts have no categorical
+     * distribution and are handled by runContinuousCrossCounts instead.
+     */
+    @Test
+    public void runCategoryCrossCounts_requiredContinuousConcept_isExcluded() {
+        String agePath = "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\";
+        PhenotypicFilter requiredAge = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, agePath, null, null, null, null);
+        Query query = new Query(List.of(), List.of(), requiredAge, null, ResultType.COUNT, null, null);
+
+        Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
+
+        assertFalse(crossCounts.containsKey(agePath), "a continuous concept should not appear in categorical cross counts");
+    }
+
+    /**
      * Two numeric range filters on the same path, OR'd, must produce a single entry whose keys are the UNION of the two ranges, not a
      * widened [min,max] span: a value sitting in the gap between the ranges must NOT appear.
      */

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
@@ -122,28 +122,34 @@ public class CountV3ProcessorIntegrationTest {
     }
 
     /**
-     * This test illustrates how there is now ambiguity in how we do cross counts when OR functionality is introduced. In this example,
-     * because there is an OR clause, the cross counts will not match the total patient set. In this case, since only "Finnish" was queried
-     * as a POPULATION_NAME, we only return cross counts for "Finnish" patients, even though the total patient set contains patients with
-     * other POPULATION_NAME.
+     * With an OR clause the cohort is broader than any single filter's values, so a cross count reports each concept's full
+     * distribution across that cohort: SEX shows female (present via the OR'd POPULATION branch) alongside the called-out male, and
+     * POPULATION shows the populations of the OR'd males alongside the called-out Finnish.
      */
     @Test
-    public void runCategoryCrossCounts_twoFiltersOr() {
-        PhenotypicFilter sexFilter =
-            new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\SEX\\", Set.of("male"), null, null, null);
-        PhenotypicFilter populationFilter = new PhenotypicFilter(
-            PhenotypicFilterType.FILTER, "\\open_access-1000Genomes\\data\\POPULATION NAME\\", Set.of("Finnish"), null, null, null
-        );
+    public void runCategoryCrossCounts_twoFiltersOr_reportsFullCohortDistribution() {
+        String sexPath = "\\open_access-1000Genomes\\data\\SEX\\";
+        String populationPath = "\\open_access-1000Genomes\\data\\POPULATION NAME\\";
+        PhenotypicFilter sexFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
+        PhenotypicFilter populationFilter =
+            new PhenotypicFilter(PhenotypicFilterType.FILTER, populationPath, Set.of("Finnish"), null, null, null);
 
         PhenotypicSubquery phenotypicSubquery = new PhenotypicSubquery(null, List.of(sexFilter, populationFilter), Operator.OR);
         Query query = new Query(List.of(), List.of(), phenotypicSubquery, null, ResultType.COUNT, null, null);
 
         Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
+
         assertEquals(2, crossCounts.size());
-        assertEquals(1, crossCounts.get("\\open_access-1000Genomes\\data\\SEX\\").size());
-        assertEquals(2648, crossCounts.get("\\open_access-1000Genomes\\data\\SEX\\").get("male"));
-        assertEquals(1, crossCounts.get("\\open_access-1000Genomes\\data\\POPULATION NAME\\").size());
-        assertEquals(102, crossCounts.get("\\open_access-1000Genomes\\data\\POPULATION NAME\\").get("Finnish"));
+        Map<String, Integer> sexCounts = crossCounts.get(sexPath);
+        // female is in the cohort via the OR'd POPULATION branch, so it appears even though only male was filtered
+        assertEquals(Set.of("male", "female"), sexCounts.keySet());
+        assertEquals(2648, sexCounts.get("male"));
+        assertTrue(sexCounts.get("female") > 0, "females in the OR cohort should be reported");
+
+        Map<String, Integer> populationCounts = crossCounts.get(populationPath);
+        // the OR'd males bring in their own populations alongside the called-out Finnish
+        assertEquals(102, populationCounts.get("Finnish"));
+        assertTrue(populationCounts.size() > 1, "populations of the OR'd males should be reported");
     }
 
     @Test
@@ -203,8 +209,8 @@ public class CountV3ProcessorIntegrationTest {
     }
 
     /**
-     * A REQUIRED filter and a value filter on the same path union to the full distribution within the (male-only) cohort: female must be
-     * present at zero rather than dropped by the value filter overwriting the REQUIRED entry.
+     * A REQUIRED filter and a value filter on the same path, AND'd, narrow the cohort to males. female has no members in that cohort and
+     * was not explicitly selected, so it is omitted (it is not "called out" by a value filter).
      */
     @Test
     public void runCategoryCrossCounts_requiredPlusFilterSamePath() {
@@ -218,9 +224,30 @@ public class CountV3ProcessorIntegrationTest {
 
         assertEquals(1, crossCounts.size());
         Map<String, Integer> sexCounts = crossCounts.get(sexPath);
+        assertEquals(Set.of("male"), sexCounts.keySet());
+        assertEquals(2648, sexCounts.get("male"));
+    }
+
+    /**
+     * Mirrors the reported bug: a value filter (SEX=male) OR'd with a REQUIRED filter on a different concept. The REQUIRED branch pulls
+     * females into the cohort, so the SEX chart must show female alongside male rather than male alone.
+     */
+    @Test
+    public void runCategoryCrossCounts_valueFilterOrRequiredOnOtherConcept_showsUnfilteredValues() {
+        String sexPath = "\\open_access-1000Genomes\\data\\SEX\\";
+        String populationPath = "\\open_access-1000Genomes\\data\\POPULATION NAME\\";
+        PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
+        PhenotypicFilter requiredPopulation = new PhenotypicFilter(PhenotypicFilterType.REQUIRED, populationPath, null, null, null, null);
+
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(maleFilter, requiredPopulation), Operator.OR);
+        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+
+        Map<String, Map<String, Integer>> crossCounts = countProcessor.runCategoryCrossCounts(query);
+
+        Map<String, Integer> sexCounts = crossCounts.get(sexPath);
         assertEquals(Set.of("male", "female"), sexCounts.keySet());
         assertEquals(2648, sexCounts.get("male"));
-        assertEquals(0, sexCounts.get("female"));
+        assertTrue(sexCounts.get("female") > 0, "females pulled into the cohort by the REQUIRED branch should be reported");
     }
 
     /**
@@ -242,6 +269,28 @@ public class CountV3ProcessorIntegrationTest {
         assertTrue(ageCounts.containsKey(31.0), "low range endpoint should be present");
         assertTrue(ageCounts.containsKey(62.0), "high range endpoint should be present");
         assertFalse(ageCounts.containsKey(44.0), "a value in the gap between the two ranges must not appear");
+    }
+
+    /**
+     * A continuous range filter OR'd with a filter on another concept: the age distribution must include ages outside the filtered [55,62]
+     * range, because the OR'd males (of all ages) are in the cohort. The range only constrains the cohort, not which values are displayed.
+     */
+    @Test
+    public void runContinuousCrossCounts_rangeOrOtherConcept_showsValuesOutsideRange() {
+        String agePath = "\\open_access-1000Genomes\\data\\SYNTHETIC_AGE\\";
+        String sexPath = "\\open_access-1000Genomes\\data\\SEX\\";
+        PhenotypicFilter oldFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, agePath, null, 55.0, 62.0, null);
+        PhenotypicFilter maleFilter = new PhenotypicFilter(PhenotypicFilterType.FILTER, sexPath, Set.of("male"), null, null, null);
+        PhenotypicSubquery subquery = new PhenotypicSubquery(null, List.of(oldFilter, maleFilter), Operator.OR);
+        Query query = new Query(List.of(), List.of(), subquery, null, ResultType.COUNT, null, null);
+
+        Map<String, Map<Double, Integer>> crossCounts = countProcessor.runContinuousCrossCounts(query);
+
+        Map<Double, Integer> ageCounts = crossCounts.get(agePath);
+        assertTrue(
+            ageCounts.keySet().stream().anyMatch(age -> age < 55.0),
+            "ages below the filtered range should appear via the OR'd males in the cohort"
+        );
     }
 
 }


### PR DESCRIPTION
## Problem

With the v3 query object, a user can add **multiple filters on the same variable** (e.g. `sex=male OR sex=female` as two `PhenotypicFilter` entries). The Advanced Filtering visualizations should show **one** chart per variable with all of that variable's values.

In `CountV3Processor`, both `runCategoryCrossCounts` and `runContinuousCrossCounts` iterated filters and did `map.put(conceptPath, …)`. A second filter on the same concept path **silently overwrote** the first's counts, and `parallelStream()` made the surviving filter non-deterministic. Downstream, charts for a duplicated variable showed only one value's data.

This is the HPDS-side root cause of the visualization ticket; the frontend, viz resource (`QueryDecomposer` already dedupes paths via `LinkedHashSet`), and binning were already correct.

## Fix

Both methods now **group filters by concept path** and emit exactly one entry per variable:

- **Categorical:** a `REQUIRED` filter on a path contributes the full category distribution; value filters contribute their named values; the two are **unioned** (REQUIRED + value filter → full distribution). Counts use `Sets.intersection` with the cohort uniformly.
- **Continuous:** range filters on a path **union** their ranges. The observed value is collected per matching patient before counting, so a patient whose value falls in two overlapping ranges is counted once.

Two adjacent bugs in the same methods are fixed by the restructure:

- **Off-by-one:** the REQUIRED branch used `getOrDefault(category, 1) + 1`, inflating a category count by one when its first in-cohort patient was seen. Replaced by `Sets.intersection` sizing.
- **Thread-safety:** non-concurrent `TreeMap`s were mutated from `parallelStream().forEach`. Grouping now runs on a sequential stream with no shared mutation.

## Tests

**Unit (mocked cubes):**
- Duplicate categorical value filters on one path merge into a single entry.
- A REQUIRED filter over a partial cohort counts each patient once (off-by-one regression).
- Duplicate numeric ranges union without counting a gap value.

**Integration (1000Genomes fixture):**
- `SEX=male OR SEX=female` → one SEX entry with both values.
- AND'd disjoint values → both values present at zero.
- REQUIRED + value filter → full distribution within the cohort.
- Two OR'd `SYNTHETIC_AGE` ranges → union of ranges, gap value excluded.

Full `mvn test` passes across all modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected categorical cross-counts so duplicate/combined filters on the same element merge values, exclude variant-spec paths, and only include categories with cohort matches or explicitly called-out keys.
  * Ensured REQUIRED filters count each patient once and preserve zero-count keys when appropriate.
  * Adjusted continuous counting to report observed cohort values (including those outside individual filter ranges).

* **Tests**
  * Added unit and integration tests for duplicate/mixed categorical filters, REQUIRED/filter interactions, and continuous-range behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update: report cross counts over the whole cohort (second fix)

A second, related bug in the same methods: a value/range filter was restricting which values a cross-count **displays**, not just which patients are in the cohort. With an `OR` that broadens the cohort via another concept, real cohort members were hidden — e.g. `sex=male OR age-required` rendered a **male-only** SEX chart even though the age branch pulls females into the cohort. This is the case the old `runCategoryCrossCounts_twoFiltersOr` test documented as intentionally "ambiguous."

A cross count now reports each filtered concept's distribution across the final cohort; the filter values/ranges only define the cohort, not the display.

- **Categorical:** a category is shown when it has members in the cohort **OR** it was explicitly named ("called out") by a value filter. A value filter no longer hides OR-branch cohort members; a value the user specifically selected is shown even at count 0 (open-access ADS obfuscates that 0 to `< threshold`); categories neither called out nor present are omitted (AND-narrowed concepts don't sprout empty bars).
- **Continuous:** report all observed values over the cohort; each filter's min/max only constrains the cohort, so an OR'd range no longer hides the other branch's out-of-range values.

Pure-AND queries are unchanged. Computed in `CountV3Processor`, which serves both the authorized (`/v3/query/sync`) and open (ADS → `/v3/query/sync`) paths — so it fixes the open-access case in the report. Tests updated accordingly (`twoFiltersOr` rewritten, `requiredPlusFilterSamePath` updated, categorical + continuous OR-cohort reproductions added).
