### PR TITLE
DO NOT MERGE - This is an old prototype for partitioned HPDS data

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,0 +1,3 @@
+FROM maven:3.9.9-amazoncorretto-24
+
+RUN yum update -y && yum install -y git && yum clean all

--- a/docker/pic-sure-hpds-etl/Dockerfile
+++ b/docker/pic-sure-hpds-etl/Dockerfile
@@ -1,37 +1,25 @@
-FROM maven:3.9.9-amazoncorretto-24 AS build
-
-RUN yum update -y && yum install -y git && yum clean all
-
-WORKDIR /app
-
-COPY .m2 /root/.m2
-
-COPY . .
-
-RUN mvn clean install -DskipTests
-
 FROM amazoncorretto:24-alpine
 
 RUN apk add --no-cache --purge -uU bash curl wget unzip gnupg openssl && \
     rm -rf /var/cache/apk/* /tmp/*
 
 WORKDIR /app
-COPY --from=build /app/docker/pic-sure-hpds-etl/SQLLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/CSVLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/CSVLoaderNewSearch-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/CSVDumper-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/VCFLocalLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/SplitChromosomeVcfLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/VariantMetadataLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/GenomicDatasetFinalizer-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/UnifiedVCFLocalLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/MultialleleCounter-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/RekeyDataset-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/RemoveConceptFromMetadata-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/HideAnnotationCategoryValue-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/SequentialLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/LowRAMMultiCSVLoader-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/CreateColumnmetaCSV-jar-with-dependencies.jar .
-COPY --from=build /app/docker/pic-sure-hpds-etl/create_key.sh .
+COPY /docker/pic-sure-hpds-etl/SQLLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/CSVLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/CSVLoaderNewSearch-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/CSVDumper-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/VCFLocalLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/SplitChromosomeVcfLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/VariantMetadataLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/GenomicDatasetFinalizer-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/UnifiedVCFLocalLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/MultialleleCounter-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/RekeyDataset-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/RemoveConceptFromMetadata-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/HideAnnotationCategoryValue-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/SequentialLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/LowRAMMultiCSVLoader-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/CreateColumnmetaCSV-jar-with-dependencies.jar .
+COPY /docker/pic-sure-hpds-etl/create_key.sh .
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -Xmx${HEAPSIZE:-2048}m -jar ${LOADER_NAME:-CSVLoader}-jar-with-dependencies.jar $LOADER_ARGS"]

--- a/docker/pic-sure-hpds/Dockerfile
+++ b/docker/pic-sure-hpds/Dockerfile
@@ -2,6 +2,6 @@ FROM amazoncorretto:24-alpine
 
 WORKDIR /app
 
-COPY /app/service/target/service-*-SNAPSHOT.jar /service.jar
+COPY /service/target/service-*-SNAPSHOT.jar /service.jar
 
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /service.jar"]

--- a/docker/pic-sure-hpds/Dockerfile
+++ b/docker/pic-sure-hpds/Dockerfile
@@ -1,9 +1,7 @@
-FROM hms-dbmi/pic-sure-hpds-build:LATEST AS hpds-build
-
 FROM amazoncorretto:24-alpine
 
 WORKDIR /app
 
-COPY --from=hpds-build /app/service/target/service-*-SNAPSHOT.jar /service.jar
+COPY /app/service/target/service-*-SNAPSHOT.jar /service.jar
 
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /service.jar"]

--- a/docker/pic-sure-hpds/build.Dockerfile
+++ b/docker/pic-sure-hpds/build.Dockerfile
@@ -1,5 +1,6 @@
-ARG PIC-SURE-API-BUILD-VERSION
-FROM hms-dbmi/pic-sure-build:${PIC-SURE-API-BUILD-VERSION} as PSB
+ARG PIC_SURE_API_BUILD_VERSION
+
+FROM hms-dbmi/pic-sure-build:${PIC_SURE_API_BUILD_VERSION} as PSB
 
 FROM maven:3.9.9-amazoncorretto-24 AS build
 

--- a/docker/pic-sure-hpds/build.Dockerfile
+++ b/docker/pic-sure-hpds/build.Dockerfile
@@ -4,6 +4,7 @@ FROM hms-dbmi/pic-sure-build:${PIC_SURE_API_BUILD_VERSION} as PSB
 
 FROM maven:3.9.9-amazoncorretto-24 AS build
 
+COPY ./settings.xml /root/.m2/settings.xml
 
 ## do we need this?
 RUN yum update -y && yum install -y git && yum clean all
@@ -11,8 +12,5 @@ RUN yum update -y && yum install -y git && yum clean all
 WORKDIR /app
 
 COPY . .
-# Extract the pic-sure-
-COPY --from=PSB /app/pic-sure-api-war/target/pic-sure-api-war/WEB-INF/lib/pic-sure-resource-api-*-SNAPSHOT.jar \
-    /root/.m2/repository/edu/harvard/hms/dbmi/avillach/pic-sure-resources/
 
 RUN mvn clean install -DskipTests

--- a/docker/pic-sure-hpds/build.Dockerfile
+++ b/docker/pic-sure-hpds/build.Dockerfile
@@ -1,12 +1,17 @@
+ARG PIC-SURE-API-BUILD-VERSION
+FROM hms-dbmi/pic-sure-build:${PIC-SURE-API-BUILD-VERSION} as PSB
+
 FROM maven:3.9.9-amazoncorretto-24 AS build
+
 
 ## do we need this?
 RUN yum update -y && yum install -y git && yum clean all
 
 WORKDIR /app
 
-COPY .m2 /root/.m2
-
 COPY . .
+# Extract the pic-sure-
+COPY --from=PSB /app/pic-sure-api-war/target/pic-sure-api-war/WEB-INF/lib/pic-sure-resource-api-*-SNAPSHOT.jar \
+    /root/.m2/repository/edu/harvard/hms/dbmi/avillach/pic-sure-resources/
 
 RUN mvn clean install -DskipTests

--- a/docker/pic-sure-hpds/build.Dockerfile
+++ b/docker/pic-sure-hpds/build.Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /app
 
 COPY . .
 
-RUN mvn clean install -DskipTests
+RUN mvn clean install -DskipTests -U

--- a/docker/pic-sure-hpds/build.Dockerfile
+++ b/docker/pic-sure-hpds/build.Dockerfile
@@ -1,6 +1,11 @@
 FROM maven:3.9.9-amazoncorretto-24 AS build
 
-COPY ./settings.xml /root/.m2/settings.xml
+RUN mkdir -p /root/.m2
+COPY settings.xml /root/.m2/settings.xml
+
+RUN echo "===== settings.xml =====" \
+ && cat /root/.m2/settings.xml \
+ && echo "========================"
 
 ## do we need this?
 RUN yum update -y && yum install -y git && yum clean all
@@ -9,4 +14,4 @@ WORKDIR /app
 
 COPY . .
 
-RUN mvn clean install -DskipTests -U
+RUN mvn -s /root/.m2/settings.xml clean install -DskipTests -U

--- a/docker/pic-sure-hpds/build.Dockerfile
+++ b/docker/pic-sure-hpds/build.Dockerfile
@@ -1,7 +1,3 @@
-ARG PIC_SURE_API_BUILD_VERSION
-
-FROM hms-dbmi/pic-sure-build:${PIC_SURE_API_BUILD_VERSION} as PSB
-
 FROM maven:3.9.9-amazoncorretto-24 AS build
 
 COPY ./settings.xml /root/.m2/settings.xml

--- a/docker/pic-sure-hpds/build.Dockerfile
+++ b/docker/pic-sure-hpds/build.Dockerfile
@@ -14,4 +14,4 @@ WORKDIR /app
 
 COPY . .
 
-RUN mvn -s /root/.m2/settings.xml clean install -DskipTests -U
+RUN mvn -s /root/.m2/settings.xml clean install -Pdeploy-local -DskipTests -U

--- a/etl/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMLoadingStore.java
+++ b/etl/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMLoadingStore.java
@@ -135,7 +135,8 @@ public class LowRAMLoadingStore {
         allObservationsTemp.close();
         File tempFile = new File(obsTempFilename);
         tempFile.delete();
-        dumpStatsAndColumnMeta("/opt/local/hpds/");
+        String outputDir = new File(columnmetaFilename).getParent() + "/";
+        dumpStatsAndColumnMeta(outputDir);
     }
 
     private void write(RandomAccessFile allObservationsStore, ColumnMeta columnMeta, PhenoCube cube) throws IOException {

--- a/etl/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMMultiCSVLoader.java
+++ b/etl/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMMultiCSVLoader.java
@@ -10,16 +10,36 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
+import static edu.harvard.hms.dbmi.avillach.hpds.crypto.Crypto.DEFAULT_KEY_NAME;
+
 public class LowRAMMultiCSVLoader {
 
     private static final Logger log = LoggerFactory.getLogger(LowRAMMultiCSVLoader.class);
-    private final LowRAMCSVProcessor processor;
     private final String inputDir;
+    private final String outputDir;
+    private final boolean rollUpVarNames;
+    private final double maxChunkSize;
+    private final ConfigLoader configLoader;
 
+    public LowRAMMultiCSVLoader(String inputDir, String outputDir, boolean rollUpVarNames, double maxChunkSize, ConfigLoader configLoader) {
+        this.inputDir = inputDir == null ? "/opt/local/hpds_input" : inputDir;
+        this.outputDir = outputDir == null ? "/opt/local/hpds/" : outputDir;
+        this.rollUpVarNames = rollUpVarNames;
+        this.maxChunkSize = maxChunkSize;
+        this.configLoader = configLoader;
+        Crypto.loadDefaultKey();
+    }
+
+    /**
+     * @deprecated Use the constructor with outputDir parameter instead.
+     */
+    @Deprecated
     public LowRAMMultiCSVLoader(LowRAMLoadingStore store, LowRAMCSVProcessor processor, String inputDir) {
         this.inputDir = inputDir == null ? "/opt/local/hpds_input" : inputDir;
-        store = store == null ? new LowRAMLoadingStore() : store;
-        this.processor = processor == null ? new LowRAMCSVProcessor(store, false, 5D) : processor;
+        this.outputDir = "/opt/local/hpds/";
+        this.rollUpVarNames = false;
+        this.maxChunkSize = 5D;
+        this.configLoader = null;
         Crypto.loadDefaultKey();
     }
 
@@ -46,29 +66,20 @@ public class LowRAMMultiCSVLoader {
         }
 
         String inputDir = "/opt/local/hpds_input";
+        String outputDir = "/opt/local/hpds/";
         ConfigLoader configLoader = new ConfigLoader();
-        LowRAMLoadingStore store = new LowRAMLoadingStore();
-        LowRAMCSVProcessor lowRAMCSVProcessor = new LowRAMCSVProcessor(store, rollUpVarNames, maxChunkSize, configLoader);
-        int exitCode = new LowRAMMultiCSVLoader(store, lowRAMCSVProcessor, inputDir).processCSVsFromHPDSDir(maxChunkSize);
-        try {
-            store.saveStore();
-        } catch (IOException | ClassNotFoundException e) {
-            log.error("Error saving store: ", e);
-            System.exit(1);
-        }
+        LowRAMMultiCSVLoader loader = new LowRAMMultiCSVLoader(inputDir, outputDir, rollUpVarNames, maxChunkSize, configLoader);
+        int exitCode = loader.processCSVsFromHPDSDir(maxChunkSize);
         System.exit(exitCode);
     }
 
     protected int processCSVsFromHPDSDir(double maxChunkSize) {
-        // find all files
         log.info("Looking for files to process. All files must be smaller than {}G", maxChunkSize);
         log.info("Files larger than {}G should be split into a series of CSVs", maxChunkSize);
         try (Stream<Path> input_files = Files.list(Path.of(inputDir))) {
             input_files.map(Path::toFile).filter(File::isFile).peek(f -> log.info("Found file {}", f.getAbsolutePath()))
-
                 .filter(f -> f.getName().endsWith(".csv")).peek(f -> log.info("Confirmed file {} is a .csv", f.getAbsolutePath()))
-
-                .map(processor::process).forEach(status -> log.info("Finished processing file {}", status));
+                .forEach(csvFile -> processOneCSV(csvFile, maxChunkSize));
             return 0;
         } catch (IOException e) {
             log.error("Exception processing files: ", e);
@@ -76,5 +87,43 @@ public class LowRAMMultiCSVLoader {
         }
     }
 
+    private void processOneCSV(File csvFile, double maxChunkSize) {
+        String shardName = deriveShardName(csvFile.getName());
+        String shardDir = outputDir + shardName + "/";
 
+        File shardDirFile = new File(shardDir);
+        if (!shardDirFile.exists() && !shardDirFile.mkdirs()) {
+            throw new UncheckedIOException(new IOException("Failed to create shard directory: " + shardDir));
+        }
+
+        String obsTempFile = shardDir + "allObservationsTemp.javabin";
+        String columnMetaFile = shardDir + "columnMeta.javabin";
+        String obsPermFile = shardDir + "allObservationsStore.javabin";
+
+        log.info("Processing CSV {} into shard directory {}", csvFile.getName(), shardDir);
+
+        LowRAMLoadingStore store = new LowRAMLoadingStore(obsTempFile, columnMetaFile, obsPermFile, DEFAULT_KEY_NAME);
+        LowRAMCSVProcessor processor = configLoader != null
+            ? new LowRAMCSVProcessor(store, rollUpVarNames, maxChunkSize, configLoader)
+            : new LowRAMCSVProcessor(store, rollUpVarNames, maxChunkSize);
+
+        IngestStatus status = processor.process(csvFile);
+        log.info("Finished processing file {}", status);
+
+        try {
+            store.saveStore();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new UncheckedIOException(new IOException("Error saving store for shard " + shardName, e));
+        }
+    }
+
+    static String deriveShardName(String csvFilename) {
+        String name = csvFilename;
+        if (name.toLowerCase().endsWith(".csv")) {
+            name = name.substring(0, name.length() - 4);
+        }
+        // Replace any non-alphanumeric characters (except - and _) with _
+        name = name.replaceAll("[^a-zA-Z0-9_\\-]", "_");
+        return "shard_" + name;
+    }
 }

--- a/etl/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMMultiCSVLoaderTest.java
+++ b/etl/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMMultiCSVLoaderTest.java
@@ -26,7 +26,7 @@ class LowRAMMultiCSVLoaderTest {
         file.close();
 
         LowRAMMultiCSVLoader subject = new LowRAMMultiCSVLoader(
-            inputDir.getAbsolutePath(), outputDir.getAbsolutePath() + "/", false, 5D, null
+            inputDir.getAbsolutePath(), outputDir.getAbsolutePath() + "/", false, 5D, null, true
         );
         int actual = subject.processCSVsFromHPDSDir(5D);
 

--- a/etl/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMMultiCSVLoaderTest.java
+++ b/etl/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/etl/phenotype/litecsv/LowRAMMultiCSVLoaderTest.java
@@ -3,64 +3,64 @@ package edu.harvard.hms.dbmi.avillach.hpds.etl.phenotype.litecsv;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 class LowRAMMultiCSVLoaderTest {
 
     @Test
     void shouldFilterOutNonCSVs(@TempDir File testDir) throws IOException {
-        Path csvPath = Path.of(testDir.getAbsolutePath(), "test.txt");
-        RandomAccessFile largeFile = new RandomAccessFile(csvPath.toString(), "rw");
-        largeFile.setLength(6L*1024);
+        File outputDir = new File(testDir, "output");
+        outputDir.mkdirs();
+        File inputDir = new File(testDir, "input");
+        inputDir.mkdirs();
 
-        LowRAMCSVProcessor processor = Mockito.mock(LowRAMCSVProcessor.class);
-        LowRAMLoadingStore store = Mockito.mock(LowRAMLoadingStore.class);
+        Path txtPath = Path.of(inputDir.getAbsolutePath(), "test.txt");
+        RandomAccessFile file = new RandomAccessFile(txtPath.toString(), "rw");
+        file.setLength(6L * 1024);
+        file.close();
 
-        LowRAMMultiCSVLoader subject = new LowRAMMultiCSVLoader(store, processor, testDir.getAbsolutePath());
+        LowRAMMultiCSVLoader subject = new LowRAMMultiCSVLoader(
+            inputDir.getAbsolutePath(), outputDir.getAbsolutePath() + "/", false, 5D, null
+        );
         int actual = subject.processCSVsFromHPDSDir(5D);
 
-        Assertions.assertEquals(0, actual);
-        Mockito.verify(processor, Mockito.times(0)).process(Mockito.any());
+        assertEquals(0, actual);
+        // No shard directories should be created for non-CSV files
+        File[] shardDirs = outputDir.listFiles(File::isDirectory);
+        assertNotNull(shardDirs);
+        assertEquals(0, shardDirs.length);
     }
 
     @Test
-    void shouldProcessSmallCSVs(@TempDir File testDir) throws IOException {
-        Path csvPath = Path.of(testDir.getAbsolutePath(), "test.csv");
-        RandomAccessFile largeFile = new RandomAccessFile(csvPath.toString(), "rw");
-        largeFile.setLength(6L*1024);
-
-        LowRAMCSVProcessor processor = Mockito.mock(LowRAMCSVProcessor.class);
-        Mockito.when(processor.process(Mockito.any()))
-            .thenReturn(new IngestStatus(csvPath, 10, 10, 10L));
-        LowRAMLoadingStore store = Mockito.mock(LowRAMLoadingStore.class);
-
-        LowRAMMultiCSVLoader subject = new LowRAMMultiCSVLoader(store, processor, testDir.getAbsolutePath());
-        int actual = subject.processCSVsFromHPDSDir(5D);
-
-        Assertions.assertEquals(0, actual);
-        Mockito.verify(processor, Mockito.times(1)).process(Mockito.any());
+    void deriveShardName_basicFilename() {
+        assertEquals("shard_study1", LowRAMMultiCSVLoader.deriveShardName("study1.csv"));
     }
 
     @Test
-    void shouldProcessSmallCSVs_withReducedChunkSize(@TempDir File testDir) throws IOException {
-        Path csvPath = Path.of(testDir.getAbsolutePath(), "test.csv");
-        RandomAccessFile largeFile = new RandomAccessFile(csvPath.toString(), "rw");
-        largeFile.setLength(6L*1024);
+    void deriveShardName_uppercaseExtension() {
+        assertEquals("shard_study1", LowRAMMultiCSVLoader.deriveShardName("study1.CSV"));
+    }
 
-        LowRAMCSVProcessor processor = Mockito.mock(LowRAMCSVProcessor.class);
-        Mockito.when(processor.process(Mockito.any()))
-                .thenReturn(new IngestStatus(csvPath, 10, 10, 10L));
-        LowRAMLoadingStore store = Mockito.mock(LowRAMLoadingStore.class);
+    @Test
+    void deriveShardName_noExtension() {
+        assertEquals("shard_study1", LowRAMMultiCSVLoader.deriveShardName("study1"));
+    }
 
-        LowRAMMultiCSVLoader subject = new LowRAMMultiCSVLoader(store, processor, testDir.getAbsolutePath());
-        int actual = subject.processCSVsFromHPDSDir(1D);
+    @Test
+    void deriveShardName_specialCharacters_sanitized() {
+        assertEquals("shard_my_study_1", LowRAMMultiCSVLoader.deriveShardName("my study 1.csv"));
+        assertEquals("shard_study_v2_0", LowRAMMultiCSVLoader.deriveShardName("study.v2.0.csv"));
+        assertEquals("shard_test-file_name", LowRAMMultiCSVLoader.deriveShardName("test-file name.csv"));
+    }
 
-        Assertions.assertEquals(0, actual);
-        Mockito.verify(processor, Mockito.times(1)).process(Mockito.any());
+    @Test
+    void deriveShardName_preservesUnderscoresAndHyphens() {
+        assertEquals("shard_my-study_name", LowRAMMultiCSVLoader.deriveShardName("my-study_name.csv"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
 			</releases>
 			<snapshots>
 				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
 			</snapshots>
 		</repository>
 
@@ -54,7 +53,6 @@
 			<url>http://reposilite:8080/releases</url>
 			<releases>
 				<enabled>true</enabled>
-				<updatePolicy>daily</updatePolicy>
 			</releases>
 			<snapshots>
 				<enabled>false</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,20 @@
 		<spotless.version>2.46.1</spotless.version>
 	</properties>
 	<repositories>
+		<!-- Local Reposilite for resolving internal snapshots/releases -->
+		<repository>
+			<id>reposilite</id>
+			<name>Reposilite</name>
+			<url>http://reposilite:8080</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+
+		<!-- Keep GitHub Packages -->
 		<repository>
 			<id>github</id>
 			<name>GitHub HMS-DBMI Apache Maven Packages</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,18 +2,22 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
+
 	<groupId>edu.harvard.hms.dbmi.avillach.hpds</groupId>
 	<artifactId>pic-sure-hpds</artifactId>
 	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>pic-sure-hpds</name>
+
 	<modules>
 		<module>common</module>
 		<module>service</module>
@@ -24,7 +28,8 @@
 		<module>genomic-processor</module>
 		<module>docker</module>
 		<module>war</module>
-    </modules>
+	</modules>
+
 	<properties>
 		<maven.compiler.release>24</maven.compiler.release>
 		<java.version>24</java.version>
@@ -33,6 +38,7 @@
 		<aws.version>2.20.153</aws.version>
 		<spotless.version>2.46.1</spotless.version>
 	</properties>
+
 	<repositories>
 		<!-- Local Reposilite for resolving internal snapshots/releases -->
 		<repository>
@@ -59,7 +65,7 @@
 			</snapshots>
 		</repository>
 
-		<!-- Keep GitHub Packages -->
+		<!-- Keep GitHub Packages for resolving (if needed) -->
 		<repository>
 			<id>github</id>
 			<name>GitHub HMS-DBMI Apache Maven Packages</name>
@@ -69,6 +75,7 @@
 			</snapshots>
 		</repository>
 	</repositories>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -97,6 +104,7 @@
 						</execution>
 					</executions>
 				</plugin>
+
 				<plugin>
 					<groupId>com.diffplug.spotless</groupId>
 					<artifactId>spotless-maven-plugin</artifactId>
@@ -112,46 +120,53 @@
 					</configuration>
 				</plugin>
 
-				<!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+				<!-- clean lifecycle -->
 				<plugin>
 					<artifactId>maven-clean-plugin</artifactId>
 					<version>3.5.0</version>
 				</plugin>
-				<!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+
+				<!-- default lifecycle -->
 				<plugin>
 					<artifactId>maven-resources-plugin</artifactId>
 					<version>3.3.1</version>
 				</plugin>
+
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.14.0</version>
 					<configuration>
-						<!--this is the target Java version-->
 						<release>24</release>
 					</configuration>
 				</plugin>
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>3.5.3</version>
 				</plugin>
+
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.4.2</version>
 				</plugin>
+
 				<plugin>
 					<artifactId>maven-install-plugin</artifactId>
 					<version>3.1.4</version>
 				</plugin>
+
 				<plugin>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>3.1.4</version>
 				</plugin>
-				<!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+
+				<!-- site lifecycle -->
 				<plugin>
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.21.0</version>
 				</plugin>
+
 				<plugin>
 					<artifactId>maven-project-info-reports-plugin</artifactId>
 					<version>3.9.0</version>
@@ -159,6 +174,7 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -170,6 +186,7 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 	</dependencies>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -177,6 +194,7 @@
 				<artifactId>spring-boot-starter-tomcat</artifactId>
 				<scope>provided</scope>
 			</dependency>
+
 			<dependency>
 				<groupId>edu.harvard.hms.dbmi.avillach.hpds</groupId>
 				<artifactId>common</artifactId>
@@ -207,6 +225,7 @@
 				<artifactId>data</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+
 			<dependency>
 				<groupId>edu.harvard.hms.dbmi.avillach</groupId>
 				<artifactId>pic-sure-resource-api</artifactId>
@@ -234,6 +253,7 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
@@ -259,6 +279,7 @@
 				<artifactId>commons-io</artifactId>
 				<version>2.20.0</version>
 			</dependency>
+
 			<dependency>
 				<groupId>javax.xml.bind</groupId>
 				<artifactId>jaxb-api</artifactId>
@@ -279,61 +300,110 @@
 				<artifactId>activation</artifactId>
 				<version>1.1.1</version>
 			</dependency>
+
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>5.18.0</version>
 				<scope>test</scope>
 			</dependency>
+
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc10</artifactId>
 				<version>19.17.0.0</version>
 			</dependency>
+
 			<dependency>
 				<groupId>io.projectreactor.netty</groupId>
 				<artifactId>reactor-netty</artifactId>
 				<version>1.2.8</version>
 			</dependency>
+
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
 				<version>2.15.3</version>
 			</dependency>
+
 			<dependency>
 				<groupId>org.apache.avro</groupId>
 				<artifactId>avro</artifactId>
 				<version>1.12.0</version>
 			</dependency>
+
 			<dependency>
 				<groupId>org.xerial.snappy</groupId>
 				<artifactId>snappy-java</artifactId>
 				<version>1.1.10.5</version>
 			</dependency>
+
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>s3</artifactId>
 				<version>${aws.version}</version>
 				<exclusions>
-					<!--Spring boot will complain about this dep on startup. It's not needed (we use SLF4J + Logback)-->
 					<exclusion>
 						<groupId>commons-logging</groupId>
 						<artifactId>commons-logging</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>
+
 			<dependency>
 				<groupId>io.swagger.core.v3</groupId>
 				<artifactId>swagger-annotations</artifactId>
 				<version>2.2.40</version>
 			</dependency>
-    </dependencies>
-  </dependencyManagement>
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>GitHub HMS-DBMI Apache Maven Packages</name>
-      <url>https://maven.pkg.github.com/hms-dbmi/pic-sure-hpds</url>
-    </repository>
-  </distributionManagement>
+		</dependencies>
+	</dependencyManagement>
+
+	<!-- Default deploy target remains GitHub Packages -->
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub HMS-DBMI Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/hms-dbmi/pic-sure-hpds</url>
+		</repository>
+	</distributionManagement>
+
+	<!-- Added: deploy to local Reposilite when -Pdeploy-local is provided -->
+	<profiles>
+		<profile>
+			<id>deploy-local</id>
+
+			<distributionManagement>
+				<snapshotRepository>
+					<id>reposilite-snapshots</id>
+					<name>Reposilite Snapshots</name>
+					<url>http://reposilite:8080/snapshots</url>
+				</snapshotRepository>
+
+				<repository>
+					<id>reposilite-releases</id>
+					<name>Reposilite Releases</name>
+					<url>http://reposilite:8080/releases</url>
+				</repository>
+			</distributionManagement>
+
+			<!-- Makes: mvn clean install -Pdeploy-local deploy during install -->
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-deploy-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>deploy-during-install</id>
+								<phase>install</phase>
+								<goals>
+									<goal>deploy</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,14 +36,28 @@
 	<repositories>
 		<!-- Local Reposilite for resolving internal snapshots/releases -->
 		<repository>
-			<id>reposilite</id>
-			<name>Reposilite</name>
-			<url>http://reposilite:8080</url>
+			<id>reposilite-snapshots</id>
+			<name>Reposilite Snapshots</name>
+			<url>http://reposilite:8080/snapshots</url>
 			<releases>
-				<enabled>true</enabled>
+				<enabled>false</enabled>
 			</releases>
 			<snapshots>
 				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+		</repository>
+
+		<repository>
+			<id>reposilite-releases</id>
+			<name>Reposilite Releases</name>
+			<url>http://reposilite:8080/releases</url>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>daily</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
 			</snapshots>
 		</repository>
 

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/PhenotypeMetaStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/PhenotypeMetaStore.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -29,6 +30,8 @@ public class PhenotypeMetaStore {
 
     private TreeSet<Integer> patientIds;
 
+    private final Map<String, String> conceptToShardDir;
+
     private final LoadingCache<String, Set<String>> childConceptCache;
 
     public TreeMap<String, ColumnMeta> getMetaStore() {
@@ -45,6 +48,10 @@ public class PhenotypeMetaStore {
 
     public ColumnMeta getColumnMeta(String columnName) {
         return metaStore.get(columnName);
+    }
+
+    public String getShardDirectory(String conceptPath) {
+        return conceptToShardDir.get(conceptPath);
     }
 
     public Set<String> loadChildConceptPaths(String conceptPath) {
@@ -65,26 +72,51 @@ public class PhenotypeMetaStore {
         @Value("${HPDS_DATA_DIRECTORY:/opt/local/hpds/}") String hpdsDataDirectory,
         @Value("${CHILD_CONCEPT_CACHE_SIZE:500}") int childConceptCacheSize
     ) {
-        String columnMetaFile = hpdsDataDirectory + "columnMeta.javabin";
-        try (ObjectInputStream objectInputStream = new ObjectInputStream(new GZIPInputStream(new FileInputStream(columnMetaFile)))) {
-            TreeMap<String, ColumnMeta> _metastore = (TreeMap<String, ColumnMeta>) objectInputStream.readObject();
-            TreeMap<String, ColumnMeta> metastoreScrubbed = new TreeMap<>();
-            for (Map.Entry<String, ColumnMeta> entry : _metastore.entrySet()) {
-                metastoreScrubbed.put(entry.getKey().replaceAll("\\ufffd", ""), entry.getValue());
-            }
-            metaStore = metastoreScrubbed;
-            patientIds = (TreeSet<Integer>) objectInputStream.readObject();
-        } catch (IOException | ClassNotFoundException e) {
-            log.warn("************************************************");
-            log.warn("Could not load metastore", e);
-            log.warn(
-                "If you meant to include phenotype data of any kind, please check that the file " + columnMetaFile
-                    + " exists and is readable by the service."
-            );
-            log.warn("************************************************");
-            metaStore = new TreeMap<>();
-            patientIds = new TreeSet<>();
+        metaStore = new TreeMap<>();
+        patientIds = new TreeSet<>();
+        conceptToShardDir = new HashMap<>();
+
+        boolean foundAny = false;
+
+        // 1. Check for legacy single-file layout
+        String legacyColumnMetaFile = hpdsDataDirectory + "columnMeta.javabin";
+        File legacyFile = new File(legacyColumnMetaFile);
+        if (legacyFile.exists()) {
+            log.info("Found legacy columnMeta.javabin at root: {}", legacyColumnMetaFile);
+            loadShardMetadata(legacyColumnMetaFile, hpdsDataDirectory);
+            foundAny = true;
         }
+
+        // 2. Scan for shard subdirectories
+        File dataDir = new File(hpdsDataDirectory);
+        File[] subdirs = dataDir.listFiles(File::isDirectory);
+        boolean foundShards = false;
+        if (subdirs != null) {
+            for (File subdir : subdirs) {
+                File shardColumnMeta = new File(subdir, "columnMeta.javabin");
+                if (shardColumnMeta.exists()) {
+                    String shardDir = subdir.getAbsolutePath() + "/";
+                    log.info("Found shard columnMeta.javabin in: {}", shardDir);
+                    loadShardMetadata(shardColumnMeta.getAbsolutePath(), shardDir);
+                    foundShards = true;
+                    foundAny = true;
+                }
+            }
+        }
+
+        // 3. Warn if both legacy and shards exist
+        if (legacyFile.exists() && foundShards) {
+            log.warn("Both legacy root columnMeta.javabin and shard subdirectories found. Loading both for migration support.");
+        }
+
+        // 4. If nothing found, log warning
+        if (!foundAny) {
+            log.warn("************************************************");
+            log.warn("No columnMeta.javabin found at {} or in any subdirectory.", hpdsDataDirectory);
+            log.warn("If you meant to include phenotype data of any kind, please check that the data directory is correct.");
+            log.warn("************************************************");
+        }
+
         childConceptCache = CacheBuilder.newBuilder().maximumSize(childConceptCacheSize).build(new CacheLoader<>() {
             @Override
             public Set<String> load(String key) {
@@ -93,12 +125,43 @@ public class PhenotypeMetaStore {
         });
     }
 
+    @SuppressWarnings("unchecked")
+    private void loadShardMetadata(String columnMetaFilePath, String shardDirectory) {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new GZIPInputStream(new FileInputStream(columnMetaFilePath)))) {
+            TreeMap<String, ColumnMeta> shardMeta = (TreeMap<String, ColumnMeta>) objectInputStream.readObject();
+            TreeSet<Integer> shardPatientIds = (TreeSet<Integer>) objectInputStream.readObject();
+
+            for (Map.Entry<String, ColumnMeta> entry : shardMeta.entrySet()) {
+                String conceptPath = entry.getKey().replaceAll("\\ufffd", "");
+                if (metaStore.containsKey(conceptPath)) {
+                    log.error("Duplicate concept '{}' found in shard {}. Keeping first occurrence.", conceptPath, shardDirectory);
+                } else {
+                    metaStore.put(conceptPath, entry.getValue());
+                    conceptToShardDir.put(conceptPath, shardDirectory);
+                }
+            }
+
+            patientIds.addAll(shardPatientIds);
+            log.info("Loaded {} concepts and {} patient IDs from {}", shardMeta.size(), shardPatientIds.size(), columnMetaFilePath);
+        } catch (IOException | ClassNotFoundException e) {
+            log.warn("Could not load metastore from {}", columnMetaFilePath, e);
+        }
+    }
+
     public PhenotypeMetaStore(
         TreeMap<String, ColumnMeta> metaStore, TreeSet<Integer> patientIds,
         @Value("${CHILD_CONCEPT_CACHE_SIZE:500}") int childConceptCacheSize
     ) {
+        this(metaStore, patientIds, childConceptCacheSize, new HashMap<>());
+    }
+
+    public PhenotypeMetaStore(
+        TreeMap<String, ColumnMeta> metaStore, TreeSet<Integer> patientIds,
+        int childConceptCacheSize, Map<String, String> conceptToShardDir
+    ) {
         this.metaStore = metaStore;
         this.patientIds = patientIds;
+        this.conceptToShardDir = conceptToShardDir;
 
         this.childConceptCache = CacheBuilder.newBuilder().maximumSize(childConceptCacheSize).build(new CacheLoader<>() {
             @Override

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicObservationStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicObservationStore.java
@@ -62,7 +62,11 @@ public class PhenotypicObservationStore {
      * @return the PhenoCube for this key
      */
     public PhenoCube<?> loadPhenoCube(String key) {
-        try (RandomAccessFile allObservationsStore = new RandomAccessFile(hpdsDataDirectory + "allObservationsStore.javabin", "r");) {
+        String shardDir = phenotypeMetaStore.getShardDirectory(key);
+        if (shardDir == null) {
+            shardDir = hpdsDataDirectory;
+        }
+        try (RandomAccessFile allObservationsStore = new RandomAccessFile(shardDir + "allObservationsStore.javabin", "r");) {
             ColumnMeta columnMeta = phenotypeMetaStore.getColumnMeta(key);
             if (columnMeta != null) {
                 allObservationsStore.seek(columnMeta.getAllObservationsOffset());

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/PhenotypeMetaStoreTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/PhenotypeMetaStoreTest.java
@@ -3,9 +3,14 @@ package edu.harvard.hms.dbmi.avillach.hpds.processing;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.*;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -58,5 +63,148 @@ class PhenotypeMetaStoreTest {
             assertEquals(Set.of("\\study1\\demographics\\age\\", "\\study1\\demographics\\sex\\"), childConceptPaths);
         }
         verify(metaStore, times(1)).keySet();
+    }
+
+    @Test
+    public void constructor_legacyMode_loadsFromRootDirectory(@TempDir File tempDir) throws Exception {
+        TreeMap<String, ColumnMeta> meta = new TreeMap<>();
+        meta.put("\\concept1\\", new ColumnMeta().setName("concept1"));
+        meta.put("\\concept2\\", new ColumnMeta().setName("concept2"));
+        TreeSet<Integer> ids = new TreeSet<>(Set.of(1, 2, 3));
+        writeColumnMeta(new File(tempDir, "columnMeta.javabin"), meta, ids);
+
+        PhenotypeMetaStore store = new PhenotypeMetaStore(tempDir.getAbsolutePath() + "/", 500);
+        assertEquals(2, store.getMetaStore().size());
+        assertTrue(store.getMetaStore().containsKey("\\concept1\\"));
+        assertTrue(store.getMetaStore().containsKey("\\concept2\\"));
+        assertEquals(3, store.getPatientIds().size());
+
+        // All concepts should map to the root directory
+        String rootDir = tempDir.getAbsolutePath() + "/";
+        assertEquals(rootDir, store.getShardDirectory("\\concept1\\"));
+        assertEquals(rootDir, store.getShardDirectory("\\concept2\\"));
+    }
+
+    @Test
+    public void constructor_multiShardMode_mergesMetadata(@TempDir File tempDir) throws Exception {
+        // Create shard1
+        File shard1Dir = new File(tempDir, "shard_study1");
+        shard1Dir.mkdirs();
+        TreeMap<String, ColumnMeta> meta1 = new TreeMap<>();
+        meta1.put("\\study1\\age\\", new ColumnMeta().setName("age"));
+        TreeSet<Integer> ids1 = new TreeSet<>(Set.of(1, 2));
+        writeColumnMeta(new File(shard1Dir, "columnMeta.javabin"), meta1, ids1);
+
+        // Create shard2
+        File shard2Dir = new File(tempDir, "shard_study2");
+        shard2Dir.mkdirs();
+        TreeMap<String, ColumnMeta> meta2 = new TreeMap<>();
+        meta2.put("\\study2\\weight\\", new ColumnMeta().setName("weight"));
+        TreeSet<Integer> ids2 = new TreeSet<>(Set.of(2, 3));
+        writeColumnMeta(new File(shard2Dir, "columnMeta.javabin"), meta2, ids2);
+
+        PhenotypeMetaStore store = new PhenotypeMetaStore(tempDir.getAbsolutePath() + "/", 500);
+        assertEquals(2, store.getMetaStore().size());
+        assertTrue(store.getMetaStore().containsKey("\\study1\\age\\"));
+        assertTrue(store.getMetaStore().containsKey("\\study2\\weight\\"));
+        // Patient IDs should be union
+        assertEquals(new TreeSet<>(Set.of(1, 2, 3)), store.getPatientIds());
+
+        // Concepts map to their respective shard directories
+        assertEquals(shard1Dir.getAbsolutePath() + "/", store.getShardDirectory("\\study1\\age\\"));
+        assertEquals(shard2Dir.getAbsolutePath() + "/", store.getShardDirectory("\\study2\\weight\\"));
+    }
+
+    @Test
+    public void constructor_mixedMode_loadsBothLegacyAndShards(@TempDir File tempDir) throws Exception {
+        // Legacy root file
+        TreeMap<String, ColumnMeta> legacyMeta = new TreeMap<>();
+        legacyMeta.put("\\legacy\\concept\\", new ColumnMeta().setName("legacy"));
+        TreeSet<Integer> legacyIds = new TreeSet<>(Set.of(10));
+        writeColumnMeta(new File(tempDir, "columnMeta.javabin"), legacyMeta, legacyIds);
+
+        // Shard subdirectory
+        File shardDir = new File(tempDir, "shard_new");
+        shardDir.mkdirs();
+        TreeMap<String, ColumnMeta> shardMeta = new TreeMap<>();
+        shardMeta.put("\\new\\concept\\", new ColumnMeta().setName("new"));
+        TreeSet<Integer> shardIds = new TreeSet<>(Set.of(20));
+        writeColumnMeta(new File(shardDir, "columnMeta.javabin"), shardMeta, shardIds);
+
+        PhenotypeMetaStore store = new PhenotypeMetaStore(tempDir.getAbsolutePath() + "/", 500);
+        assertEquals(2, store.getMetaStore().size());
+        assertTrue(store.getMetaStore().containsKey("\\legacy\\concept\\"));
+        assertTrue(store.getMetaStore().containsKey("\\new\\concept\\"));
+        assertEquals(new TreeSet<>(Set.of(10, 20)), store.getPatientIds());
+    }
+
+    @Test
+    public void constructor_emptyDirectory_noFiles(@TempDir File tempDir) {
+        PhenotypeMetaStore store = new PhenotypeMetaStore(tempDir.getAbsolutePath() + "/", 500);
+        assertTrue(store.getMetaStore().isEmpty());
+        assertTrue(store.getPatientIds().isEmpty());
+    }
+
+    @Test
+    public void constructor_duplicateConcept_keepsFirst(@TempDir File tempDir) throws Exception {
+        // Create shard1 with concept
+        File shard1Dir = new File(tempDir, "shard_a");
+        shard1Dir.mkdirs();
+        TreeMap<String, ColumnMeta> meta1 = new TreeMap<>();
+        ColumnMeta firstMeta = new ColumnMeta().setName("first").setObservationCount(100);
+        meta1.put("\\shared\\concept\\", firstMeta);
+        writeColumnMeta(new File(shard1Dir, "columnMeta.javabin"), meta1, new TreeSet<>(Set.of(1)));
+
+        // Create shard2 with same concept
+        File shard2Dir = new File(tempDir, "shard_b");
+        shard2Dir.mkdirs();
+        TreeMap<String, ColumnMeta> meta2 = new TreeMap<>();
+        ColumnMeta secondMeta = new ColumnMeta().setName("second").setObservationCount(200);
+        meta2.put("\\shared\\concept\\", secondMeta);
+        writeColumnMeta(new File(shard2Dir, "columnMeta.javabin"), meta2, new TreeSet<>(Set.of(2)));
+
+        PhenotypeMetaStore store = new PhenotypeMetaStore(tempDir.getAbsolutePath() + "/", 500);
+        // Only one concept should exist
+        assertEquals(1, store.getMetaStore().size());
+        // First shard alphabetically wins (shard_a before shard_b)
+        assertEquals(shard1Dir.getAbsolutePath() + "/", store.getShardDirectory("\\shared\\concept\\"));
+    }
+
+    @Test
+    public void getShardDirectory_returnsCorrectPath() {
+        Map<String, String> shardMap = Map.of(
+            "\\concept1\\", "/data/shard1/",
+            "\\concept2\\", "/data/shard2/"
+        );
+        PhenotypeMetaStore store = new PhenotypeMetaStore(new TreeMap<>(), new TreeSet<>(), 500, shardMap);
+        assertEquals("/data/shard1/", store.getShardDirectory("\\concept1\\"));
+        assertEquals("/data/shard2/", store.getShardDirectory("\\concept2\\"));
+        assertNull(store.getShardDirectory("\\nonexistent\\"));
+    }
+
+    @Test
+    public void constructor_emptySubdirectory_skipped(@TempDir File tempDir) throws Exception {
+        // Create a subdirectory with no javabin files
+        File emptySubDir = new File(tempDir, "empty_shard");
+        emptySubDir.mkdirs();
+
+        // Create a valid shard
+        File validShardDir = new File(tempDir, "shard_valid");
+        validShardDir.mkdirs();
+        TreeMap<String, ColumnMeta> meta = new TreeMap<>();
+        meta.put("\\valid\\concept\\", new ColumnMeta().setName("valid"));
+        writeColumnMeta(new File(validShardDir, "columnMeta.javabin"), meta, new TreeSet<>(Set.of(1)));
+
+        PhenotypeMetaStore store = new PhenotypeMetaStore(tempDir.getAbsolutePath() + "/", 500);
+        assertEquals(1, store.getMetaStore().size());
+        assertTrue(store.getMetaStore().containsKey("\\valid\\concept\\"));
+    }
+
+    private void writeColumnMeta(File file, TreeMap<String, ColumnMeta> meta, TreeSet<Integer> patientIds) throws Exception {
+        try (ObjectOutputStream oos = new ObjectOutputStream(new GZIPOutputStream(new FileOutputStream(file)))) {
+            oos.writeObject(meta);
+            oos.writeObject(patientIds);
+            oos.flush();
+        }
     }
 }


### PR DESCRIPTION
# DO NOT MERGE
## ETL
  With sharding processWithSharding calls processOneCSV for each CSV independently. Each CSV gets:
1. A shard name derived from the filename deriveShardName strips .csv, sanitizes non-alphanumerics to _, and prefixes shard_ (e.g. labs.csv → shard_labs). 
2. Its own subdirectory outputDir + shardName + "/", created via mkdirs
3. Its own LowRAMLoadingStore writing a complete, self-contained triple of allObservationsTemp.javabin, columnMeta.javabin, and allObservationsStore.javabin inside that shard directory.

So the difference is purely topological: instead of one big columnMeta.javabin + allObservationsStore.javabin at the root, you get N subdirectories, each holding the full javabin set for the concepts that came from one CSV.

## HPDS
PhenotypeMetaStore is the in-memory index loaded at startup. The sharding changes turn it from "load one file" into "merge many shards into one logical view."

New state:
  - metaStore - the merged TreeMap<String,ColumnMeta> across all shards (unchanged in type).
  - patientIds - union of all shards' patient ID sets.
  - conceptToShardDir - new Map<String,String> mapping each concept path → the directory whose allObservationsStore.javabin holds its bytes. This is
  the crucial routing table.
  
Loading (constructor, line 71-127):
1. Always checks for a root-level columnMeta.javabin and loads it if present, pointing those concepts at the root dir.
2. If HPDS_SHARDING_ENABLED=true (line 74, default false), it lists subdirectories of HPDS_DATA_DIRECTORY and loads any columnMeta.javabin found in
  each, pointing those concepts at the shard dir. 
3. If both root and shards exist, it logs a warning and loads both explicitly "for migration support".
4. If nothing is found, logs the "no phenotype data" warning.
  
Merge logic - loadShardMetadata: for each shard it deserializes the TreeMap + TreeSet, strips a stray \ufffd replacement char from concept paths, and for every concept:
  - puts it into the merged metaStore,
  - records conceptToShardDir.put(conceptPath, shardDirectory),
  - detects collisions: if a concept already exists, it logs an error and keeps the first occurrence. So concept paths are expected to be globally unique across shards.

Patient IDs are unioned across all shards.

New accessor - getShardDirectory(conceptPath): returns which directory a concept lives in. This is the public surface the read path uses to find the right store file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for data sharding in ETL processing to handle distributed phenotypic data across multiple directories.
  * Integrated shard-aware metadata loading for improved data organization.

* **Infrastructure**
  * Optimized Docker build process with pre-built artifact staging.
  * Added Maven deployment profile for internal package repository management.

* **Tests**
  * Expanded test coverage for sharding behavior and metadata loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->