### PR TITLE
WIP: Phase 3 — HPDS Actuator deep health

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -80,6 +80,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>edu.harvard.dbmi.avillach</groupId>
 			<artifactId>pic-sure-logging-client</artifactId>
 		</dependency>

--- a/service/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/service/health/HpdsReadinessHealthIndicator.java
+++ b/service/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/service/health/HpdsReadinessHealthIndicator.java
@@ -1,0 +1,38 @@
+package edu.harvard.hms.dbmi.avillach.hpds.service.health;
+
+import edu.harvard.hms.dbmi.avillach.hpds.processing.AbstractProcessor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deep readiness for HPDS (spec 3.8): UP only when phenotype OR genomic data is
+ * actually loaded — a real "data ready" signal, not just port-up. HPDS has no
+ * DataSource, so this replaces the built-in db indicator.
+ */
+@Component("hpdsReadiness")
+public class HpdsReadinessHealthIndicator implements HealthIndicator {
+
+    private final AbstractProcessor abstractProcessor;
+
+    public HpdsReadinessHealthIndicator(AbstractProcessor abstractProcessor) {
+        this.abstractProcessor = abstractProcessor;
+    }
+
+    @Override
+    public Health health() {
+        try {
+            int phenotypeColumns = abstractProcessor.getDictionary().size();
+            int genomicColumns = abstractProcessor.getInfoStoreColumns().size();
+            if (phenotypeColumns > 0 || genomicColumns > 0) {
+                return Health.up()
+                    .withDetail("phenotypeColumns", phenotypeColumns)
+                    .withDetail("genomicColumns", genomicColumns)
+                    .build();
+            }
+            return Health.down().withDetail("reason", "no phenotype or genomic data loaded").build();
+        } catch (Exception ex) {
+            return Health.down(ex).build();
+        }
+    }
+}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -12,3 +12,9 @@ enable_file_sharing=false
 # This should only be set to true if you wish to control patient data access granularly
 # See edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query.authorizationFilters for more information
 # hpds.requireAuthorizationFilter=false
+
+# Actuator: deep health readiness (Phase 3). HPDS has no Spring Security, so exposing
+# health details here is safe and useful for AIO deployment health checks.
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=always
+management.endpoint.health.probes.enabled=true

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/health/HpdsReadinessHealthIndicatorTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/health/HpdsReadinessHealthIndicatorTest.java
@@ -1,0 +1,45 @@
+package edu.harvard.hms.dbmi.avillach.hpds.service.health;
+
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.AbstractProcessor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HpdsReadinessHealthIndicatorTest {
+
+    @Test
+    void upWhenPhenotypeDataLoaded() {
+        AbstractProcessor proc = mock(AbstractProcessor.class);
+        TreeMap<String, ColumnMeta> dict = new TreeMap<>();
+        dict.put("\\demographics\\AGE\\", mock(ColumnMeta.class));
+        when(proc.getDictionary()).thenReturn(dict);
+        when(proc.getInfoStoreColumns()).thenReturn(Set.of());
+
+        assertThat(new HpdsReadinessHealthIndicator(proc).health().getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    void upWhenGenomicDataLoaded() {
+        AbstractProcessor proc = mock(AbstractProcessor.class);
+        when(proc.getDictionary()).thenReturn(new TreeMap<>());
+        when(proc.getInfoStoreColumns()).thenReturn(Set.of("Gene_with_variant"));
+
+        assertThat(new HpdsReadinessHealthIndicator(proc).health().getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    void downWhenNoDataLoaded() {
+        AbstractProcessor proc = mock(AbstractProcessor.class);
+        when(proc.getDictionary()).thenReturn(new TreeMap<>());
+        when(proc.getInfoStoreColumns()).thenReturn(Set.of());
+
+        assertThat(new HpdsReadinessHealthIndicator(proc).health().getStatus()).isEqualTo(Status.DOWN);
+    }
+}


### PR DESCRIPTION
**WIP / draft** — Phase 3 (Task 5): expose Actuator `/actuator/health` on the HPDS `service` module with a deep `HpdsReadinessHealthIndicator` (UP only when the store is ready to serve). Behavior-preserving. Enables the gateway's Phase-3 deep-health aggregation to report HPDS. Stacked per design spec §9; base `pic_sure_api_rewrite`.
