### PR TITLE
ALS-12139: Implement phenotypic partitioning, part 1/n

### DIFF
--- a/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/ColumnMeta.java
+++ b/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/ColumnMeta.java
@@ -105,15 +105,16 @@ public class ColumnMeta implements Serializable {
         return categoryValues;
     }
 
-    public void setCategoryValues(List<String> categoryValues) {
+    public ColumnMeta setCategoryValues(List<String> categoryValues) {
         this.categoryValues = categoryValues;
+        return this;
     }
 
     public Double getMin() {
         return min;
     }
 
-    public ColumnMeta setMin(double min) {
+    public ColumnMeta setMin(Double min) {
         this.min = min;
         return this;
     }
@@ -122,7 +123,7 @@ public class ColumnMeta implements Serializable {
         return max;
     }
 
-    public ColumnMeta setMax(double max) {
+    public ColumnMeta setMax(Double max) {
         this.max = max;
         return this;
     }

--- a/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/ColumnMeta.java
+++ b/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/ColumnMeta.java
@@ -92,7 +92,7 @@ public class ColumnMeta implements Serializable {
         return this;
     }
 
-    public long getPatientCount() {
+    public int getPatientCount() {
         return patientCount;
     }
 

--- a/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/SummaryColumnMeta.java
+++ b/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/SummaryColumnMeta.java
@@ -3,19 +3,29 @@ package edu.harvard.hms.dbmi.avillach.hpds.data.phenotype;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class SummaryColumnMeta {
+/**
+ * {@ColumnMeta ColumnMeta} fields that apply globally to a column and can be aggregated across partitioned data.
+ */
+public class SummaryColumnMeta implements Serializable {
 
     private static final Logger log = LoggerFactory.getLogger(SummaryColumnMeta.class);
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String name;
     private int widthInBytes;
     private boolean categorical;
-    private List<String> categoryValues = List.of();
+    private Set<String> categoryValues = Set.of();
     private Double min, max;
     private int patientCount;
     private boolean hasTimestamp;
@@ -26,7 +36,7 @@ public class SummaryColumnMeta {
         this.name = columnMeta.getName();
         this.widthInBytes = columnMeta.getWidthInBytes();
         this.categorical = columnMeta.isCategorical();
-        this.categoryValues = columnMeta.getCategoryValues();
+        this.categoryValues = Set.copyOf(columnMeta.getCategoryValues());
         this.min = columnMeta.getMin();
         this.max = columnMeta.getMax();
         this.patientCount = columnMeta.getPatientCount();
@@ -37,7 +47,7 @@ public class SummaryColumnMeta {
 
     public SummaryColumnMeta() {}
 
-    public SummaryColumnMeta merge(ColumnMeta columnMeta) {
+    public SummaryColumnMeta merge(SummaryColumnMeta columnMeta) {
         SummaryColumnMeta newSummaryColumnMeta = new SummaryColumnMeta();
 
         if (!Objects.equals(this.name, columnMeta.getName())) {
@@ -60,7 +70,7 @@ public class SummaryColumnMeta {
         newSummaryColumnMeta.categoryValues = Stream.concat(
             categoryValues != null ? categoryValues.stream() : Stream.of(),
             columnMeta.getCategoryValues() != null ? columnMeta.getCategoryValues().stream() : Stream.of()
-        ).collect(Collectors.toList());
+        ).collect(Collectors.toSet());
 
         if (columnMeta.getMin() != null) {
             newSummaryColumnMeta.min = this.min == null ? columnMeta.getMin() : Double.min(this.min, columnMeta.getMin());
@@ -108,7 +118,7 @@ public class SummaryColumnMeta {
         return categorical;
     }
 
-    public List<String> getCategoryValues() {
+    public Set<String> getCategoryValues() {
         return categoryValues;
     }
 
@@ -124,7 +134,7 @@ public class SummaryColumnMeta {
         return patientCount;
     }
 
-    public boolean isHasTimestamp() {
+    public boolean hasTimestamp() {
         return hasTimestamp;
     }
 
@@ -141,22 +151,27 @@ public class SummaryColumnMeta {
         return this;
     }
 
+    public SummaryColumnMeta setWidthInBytes(int widthInBytes) {
+        this.widthInBytes = widthInBytes;
+        return this;
+    }
+
     public SummaryColumnMeta setCategorical(boolean categorical) {
         this.categorical = categorical;
         return this;
     }
 
-    public SummaryColumnMeta setCategoryValues(List<String> categoryValues) {
+    public SummaryColumnMeta setCategoryValues(Set<String> categoryValues) {
         this.categoryValues = categoryValues;
         return this;
     }
 
-    public SummaryColumnMeta setMin(double min) {
+    public SummaryColumnMeta setMin(Double min) {
         this.min = min;
         return this;
     }
 
-    public SummaryColumnMeta setMax(double max) {
+    public SummaryColumnMeta setMax(Double max) {
         this.max = max;
         return this;
     }
@@ -179,5 +194,29 @@ public class SummaryColumnMeta {
     public SummaryColumnMeta setTimestampMax(Long timestampMax) {
         this.timestampMax = timestampMax;
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        SummaryColumnMeta that = (SummaryColumnMeta) o;
+        return widthInBytes == that.widthInBytes && categorical == that.categorical && patientCount == that.patientCount
+            && hasTimestamp == that.hasTimestamp && Objects.equals(name, that.name) && Objects.equals(categoryValues, that.categoryValues)
+            && Objects.equals(min, that.min) && Objects.equals(max, that.max) && Objects.equals(timestampMin, that.timestampMin)
+            && Objects.equals(timestampMax, that.timestampMax);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects
+            .hash(name, widthInBytes, categorical, categoryValues, min, max, patientCount, hasTimestamp, timestampMin, timestampMax);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SummaryColumnMeta.class.getSimpleName() + "[", "]").add("name='" + name + "'")
+            .add("widthInBytes=" + widthInBytes).add("categorical=" + categorical).add("categoryValues=" + categoryValues).add("min=" + min)
+            .add("max=" + max).add("patientCount=" + patientCount).add("hasTimestamp=" + hasTimestamp).add("timestampMin=" + timestampMin)
+            .add("timestampMax=" + timestampMax).toString();
     }
 }

--- a/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/SummaryColumnMeta.java
+++ b/data/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/SummaryColumnMeta.java
@@ -1,0 +1,183 @@
+package edu.harvard.hms.dbmi.avillach.hpds.data.phenotype;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SummaryColumnMeta {
+
+    private static final Logger log = LoggerFactory.getLogger(SummaryColumnMeta.class);
+
+    private String name;
+    private int widthInBytes;
+    private boolean categorical;
+    private List<String> categoryValues = List.of();
+    private Double min, max;
+    private int patientCount;
+    private boolean hasTimestamp;
+    private Long timestampMin;
+    private Long timestampMax;
+
+    public SummaryColumnMeta(ColumnMeta columnMeta) {
+        this.name = columnMeta.getName();
+        this.widthInBytes = columnMeta.getWidthInBytes();
+        this.categorical = columnMeta.isCategorical();
+        this.categoryValues = columnMeta.getCategoryValues();
+        this.min = columnMeta.getMin();
+        this.max = columnMeta.getMax();
+        this.patientCount = columnMeta.getPatientCount();
+        this.hasTimestamp = columnMeta.hasTimestamp();
+        this.timestampMin = columnMeta.getTimestampMin();
+        this.timestampMax = columnMeta.getTimestampMax();
+    }
+
+    public SummaryColumnMeta() {}
+
+    public SummaryColumnMeta merge(ColumnMeta columnMeta) {
+        SummaryColumnMeta newSummaryColumnMeta = new SummaryColumnMeta();
+
+        if (!Objects.equals(this.name, columnMeta.getName())) {
+            log.warn("ColumnMeta names do not match: {} and {}", this.name, columnMeta.getName());
+        }
+        newSummaryColumnMeta.name = this.name;
+
+        if (this.widthInBytes != columnMeta.getWidthInBytes()) {
+            log.warn(
+                "ColumnMeta {} widthInBytes values do not match: {} and {}", this.name, this.widthInBytes, columnMeta.getWidthInBytes()
+            );
+        }
+        newSummaryColumnMeta.widthInBytes = Integer.max(this.widthInBytes, columnMeta.getWidthInBytes());
+
+        if (this.categorical != columnMeta.isCategorical()) {
+            log.warn("ColumnMeta {} categorical values do not match: {} and {}", this.name, this.categorical, columnMeta.isCategorical());
+        }
+        newSummaryColumnMeta.categorical = this.categorical;
+
+        newSummaryColumnMeta.categoryValues = Stream.concat(
+            categoryValues != null ? categoryValues.stream() : Stream.of(),
+            columnMeta.getCategoryValues() != null ? columnMeta.getCategoryValues().stream() : Stream.of()
+        ).collect(Collectors.toList());
+
+        if (columnMeta.getMin() != null) {
+            newSummaryColumnMeta.min = this.min == null ? columnMeta.getMin() : Double.min(this.min, columnMeta.getMin());
+        } else {
+            newSummaryColumnMeta.min = this.min;
+        }
+
+        if (columnMeta.getMax() != null) {
+            newSummaryColumnMeta.max = this.max == null ? columnMeta.getMax() : Double.max(this.max, columnMeta.getMax());
+        } else {
+            newSummaryColumnMeta.max = this.max;
+        }
+
+        // todo: can patients be in different partitions for the same concept path? if so, this will be inaccurate
+        newSummaryColumnMeta.patientCount = this.patientCount + columnMeta.getPatientCount();
+        newSummaryColumnMeta.hasTimestamp = this.hasTimestamp || columnMeta.hasTimestamp();
+
+        if (columnMeta.getTimestampMin() != null) {
+            newSummaryColumnMeta.timestampMin =
+                this.timestampMin == null ? columnMeta.getTimestampMin() : Long.min(this.timestampMin, columnMeta.getTimestampMin());
+        } else {
+            newSummaryColumnMeta.timestampMin = this.timestampMin;
+        }
+
+        if (columnMeta.getTimestampMax() != null) {
+            newSummaryColumnMeta.timestampMax =
+                this.timestampMax == null ? columnMeta.getTimestampMax() : Long.max(this.timestampMax, columnMeta.getTimestampMax());
+        } else {
+            newSummaryColumnMeta.timestampMax = this.timestampMax;
+        }
+
+        return newSummaryColumnMeta;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+    public int getWidthInBytes() {
+        return widthInBytes;
+    }
+
+    public boolean isCategorical() {
+        return categorical;
+    }
+
+    public List<String> getCategoryValues() {
+        return categoryValues;
+    }
+
+    public Double getMin() {
+        return min;
+    }
+
+    public Double getMax() {
+        return max;
+    }
+
+    public int getPatientCount() {
+        return patientCount;
+    }
+
+    public boolean isHasTimestamp() {
+        return hasTimestamp;
+    }
+
+    public Long getTimestampMin() {
+        return timestampMin;
+    }
+
+    public Long getTimestampMax() {
+        return timestampMax;
+    }
+
+    public SummaryColumnMeta setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public SummaryColumnMeta setCategorical(boolean categorical) {
+        this.categorical = categorical;
+        return this;
+    }
+
+    public SummaryColumnMeta setCategoryValues(List<String> categoryValues) {
+        this.categoryValues = categoryValues;
+        return this;
+    }
+
+    public SummaryColumnMeta setMin(double min) {
+        this.min = min;
+        return this;
+    }
+
+    public SummaryColumnMeta setMax(double max) {
+        this.max = max;
+        return this;
+    }
+
+    public SummaryColumnMeta setPatientCount(int patientCount) {
+        this.patientCount = patientCount;
+        return this;
+    }
+
+    public SummaryColumnMeta setHasTimestamp(boolean hasTimestamp) {
+        this.hasTimestamp = hasTimestamp;
+        return this;
+    }
+
+    public SummaryColumnMeta setTimestampMin(Long timestampMin) {
+        this.timestampMin = timestampMin;
+        return this;
+    }
+
+    public SummaryColumnMeta setTimestampMax(Long timestampMax) {
+        this.timestampMax = timestampMax;
+        return this;
+    }
+}

--- a/data/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/SummaryColumnMetaTest.java
+++ b/data/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/data/phenotype/SummaryColumnMetaTest.java
@@ -1,0 +1,110 @@
+package edu.harvard.hms.dbmi.avillach.hpds.data.phenotype;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SummaryColumnMetaTest {
+
+    @Test
+    public void merge_bothValidData_defaultFirstValue() {
+        SummaryColumnMeta entity1 = new SummaryColumnMeta();
+        SummaryColumnMeta entity2 = new SummaryColumnMeta();
+
+        entity1.setName("name1").setWidthInBytes(4).setCategorical(true).setCategoryValues(Set.of("James", "Jean-Luc")).setMin(10.0)
+            .setMax(40.0).setPatientCount(300).setHasTimestamp(false);
+
+        entity2.setName("name2").setWidthInBytes(8).setCategorical(false).setCategoryValues(Set.of("Benjamin", "Kathryn")).setMin(20.0)
+            .setMax(50.0).setPatientCount(300).setHasTimestamp(false);
+
+        SummaryColumnMeta merged = entity1.merge(entity2);
+        assertEquals("name1", merged.getName());
+        assertEquals(8, merged.getWidthInBytes());
+        assertTrue(merged.isCategorical());
+        assertEquals(Set.of("James", "Jean-Luc", "Benjamin", "Kathryn"), merged.getCategoryValues());
+        assertEquals(10, merged.getMin());
+        assertEquals(50, merged.getMax());
+        assertEquals(600, merged.getPatientCount());
+        assertFalse(merged.hasTimestamp());
+
+        merged = entity2.merge(entity1);
+        assertEquals("name2", merged.getName());
+        assertEquals(8, merged.getWidthInBytes());
+        assertFalse(merged.isCategorical());
+        assertEquals(Set.of("James", "Jean-Luc", "Benjamin", "Kathryn"), merged.getCategoryValues());
+        assertEquals(10, merged.getMin());
+        assertEquals(50, merged.getMax());
+        assertEquals(600, merged.getPatientCount());
+        assertFalse(merged.hasTimestamp());
+    }
+
+    @Test
+    public void merge_emptyValues() {
+        SummaryColumnMeta entity1 = new SummaryColumnMeta();
+        SummaryColumnMeta entity2 = new SummaryColumnMeta();
+
+        SummaryColumnMeta merged = entity1.merge(entity2);
+        assertNull(merged.getName());
+        assertEquals(0, merged.getWidthInBytes());
+        assertFalse(merged.isCategorical());
+        assertEquals(Set.of(), merged.getCategoryValues());
+        assertNull(merged.getMin());
+        assertNull(merged.getMax());
+        assertEquals(0, merged.getPatientCount());
+        assertFalse(merged.hasTimestamp());
+        assertNull(merged.getTimestampMax());
+        assertNull(merged.getTimestampMin());
+
+        merged = entity2.merge(entity1);
+        assertNull(merged.getName());
+        assertEquals(0, merged.getWidthInBytes());
+        assertFalse(merged.isCategorical());
+        assertEquals(Set.of(), merged.getCategoryValues());
+        assertNull(merged.getMin());
+        assertNull(merged.getMax());
+        assertEquals(0, merged.getPatientCount());
+        assertFalse(merged.hasTimestamp());
+        assertNull(merged.getTimestampMax());
+        assertNull(merged.getTimestampMin());
+    }
+
+
+    @Test
+    public void merge_oneNullMinMax_useOtherValue() {
+        SummaryColumnMeta entity1 = new SummaryColumnMeta();
+        SummaryColumnMeta entity2 = new SummaryColumnMeta();
+
+        entity1.setName("name1").setWidthInBytes(4).setCategorical(true).setCategoryValues(Set.of("James", "Jean-Luc")).setMin(null)
+            .setMax(null).setPatientCount(300).setHasTimestamp(true);
+
+        entity2.setName("name2").setWidthInBytes(8).setCategorical(false).setCategoryValues(Set.of("Benjamin", "Kathryn")).setMin(20.0)
+            .setMax(50.0).setPatientCount(300).setHasTimestamp(true).setTimestampMax(100L).setTimestampMin(1000L);
+
+        SummaryColumnMeta merged = entity1.merge(entity2);
+        assertEquals(20.0, merged.getMin());
+        assertEquals(50.0, merged.getMax());
+        assertEquals(100L, merged.getTimestampMax());
+        assertEquals(1000L, merged.getTimestampMin());
+
+        merged = entity2.merge(entity1);
+        assertEquals(20.0, merged.getMin());
+        assertEquals(50.0, merged.getMax());
+        assertEquals(100L, merged.getTimestampMax());
+        assertEquals(1000L, merged.getTimestampMin());
+    }
+
+    @Test
+    public void merge_oneNullCategoryValues_setOther() {
+        SummaryColumnMeta entity1 = new SummaryColumnMeta();
+        SummaryColumnMeta entity2 = new SummaryColumnMeta();
+
+        entity1.setCategoryValues(Set.of("Blue", "Green", "Red"));
+        SummaryColumnMeta merged = entity1.merge(entity2);
+        assertEquals(Set.of("Blue", "Green", "Red"), merged.getCategoryValues());
+
+        merged = entity2.merge(entity1);
+        assertEquals(Set.of("Blue", "Green", "Red"), merged.getCategoryValues());
+    }
+}

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/OutputColumn.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/OutputColumn.java
@@ -1,0 +1,6 @@
+package edu.harvard.hms.dbmi.avillach.hpds.processing;
+
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
+
+public record OutputColumn(SummaryColumnMeta columnMeta, int columnOffset) {
+}

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/PhenotypeMetaStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/PhenotypeMetaStore.java
@@ -65,7 +65,7 @@ public class PhenotypeMetaStore {
         @Value("${HPDS_DATA_DIRECTORY:/opt/local/hpds/}") String hpdsDataDirectory,
         @Value("${CHILD_CONCEPT_CACHE_SIZE:500}") int childConceptCacheSize
     ) {
-        String columnMetaFile = hpdsDataDirectory + "columnMeta.javabin";
+        String columnMetaFile = hpdsDataDirectory + "/columnMeta.javabin";
         try (ObjectInputStream objectInputStream = new ObjectInputStream(new GZIPInputStream(new FileInputStream(columnMetaFile)))) {
             TreeMap<String, ColumnMeta> _metastore = (TreeMap<String, ColumnMeta>) objectInputStream.readObject();
             TreeMap<String, ColumnMeta> metastoreScrubbed = new TreeMap<>();

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/QueryProcessor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/QueryProcessor.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genomic.VariantUtils;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.VariableVariantMasks;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,9 +59,9 @@ public class QueryProcessor implements HpdsProcessor {
 
 
     private ResultStore buildResult(AsyncResult result, Query query, TreeSet<Integer> ids) {
-        List<ColumnMeta> columns =
-            query.getFields().stream().map(abstractProcessor.getDictionary()::get).filter(Objects::nonNull).collect(Collectors.toList());
-        List<String> paths = columns.stream().map(ColumnMeta::getName).collect(Collectors.toList());
+        List<SummaryColumnMeta> columns = query.getFields().stream().map(abstractProcessor.getDictionary()::get).filter(Objects::nonNull)
+            .map(SummaryColumnMeta::new).collect(Collectors.toList());
+        List<String> paths = columns.stream().map(SummaryColumnMeta::getName).collect(Collectors.toList());
         int columnCount = paths.size() + 1;
 
         ArrayList<Integer> columnIndex = abstractProcessor.useResidentCubesFirst(paths, columnCount);

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/ResultStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/ResultStore.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
 import java.util.*;
 
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,159 +14,160 @@ import edu.harvard.hms.dbmi.avillach.hpds.exception.NotEnoughMemoryException;
 import edu.harvard.hms.dbmi.avillach.hpds.exception.ResultSetTooLargeException;
 
 /**
- * This class handles composing a segment of a data export file in memory. The goal here
- * is to prevent memory errors during data export and maximize concurrency for processing
- * concepts.
+ * This class handles composing a segment of a data export file in memory. The goal here is to prevent memory errors during data export and
+ * maximize concurrency for processing concepts.
  * 
  * Each ResultStore instance allocates a byte[] called resultArray. The size of this array is:
  * 
- *  (maximum width of a row in the results) * (number of patients in the result segment)
- *  
- * The maximum width of a row in the result is the sum of the maximum widths in bytes of all
- * columns. This width is stored when the data is loaded initially in the column meta for the
- * concept.
+ * (maximum width of a row in the results) * (number of patients in the result segment)
  * 
- * If the size of the array exceeds the maximum size for an array(Integer.MAX_VALUE) then a
- * {@link ResultSetTooLargeException} is thrown with a message that suggests the user select fewer fields.
+ * The maximum width of a row in the result is the sum of the maximum widths in bytes of all columns. This width is stored when the data is
+ * loaded initially in the column meta for the concept.
  * 
- * If the size of the resultArray exceeds the available heap in the JVM a NotEnoughMemoryException
- * is thrown. The only recourse here is to increase the amount of available heap or make the BATCH_SIZE 
- * system property smaller. One way to increase the amount of available heap is to reduce the CACHE_SIZE
- * system property, but that has to be balanced against the performance of non-export queries. Finding 
- * the ideal settings for these properties is a trial and error process for each dataset and user-base.
+ * If the size of the array exceeds the maximum size for an array(Integer.MAX_VALUE) then a {@link ResultSetTooLargeException} is thrown
+ * with a message that suggests the user select fewer fields.
  * 
- * The resultArray approach allows us to build the entire CSV segment concurrently for multiple concepts
- * without any synchronization overhead. Each concept is written into a dedicated fixed-width region of 
- * the resultArray. These regions do not overlap and a single thread is used for each concept, so there
- * are never two threads writing to the same location at the same time.
+ * If the size of the resultArray exceeds the available heap in the JVM a NotEnoughMemoryException is thrown. The only recourse here is to
+ * increase the amount of available heap or make the BATCH_SIZE system property smaller. One way to increase the amount of available heap is
+ * to reduce the CACHE_SIZE system property, but that has to be balanced against the performance of non-export queries. Finding the ideal
+ * settings for these properties is a trial and error process for each dataset and user-base.
  * 
- * The data is then read out of this fixed width structure into a String[] at the time it is written to
- * a temp file for the result by the {@link ResultStoreStream} class.
+ * The resultArray approach allows us to build the entire CSV segment concurrently for multiple concepts without any synchronization
+ * overhead. Each concept is written into a dedicated fixed-width region of the resultArray. These regions do not overlap and a single
+ * thread is used for each concept, so there are never two threads writing to the same location at the same time.
+ * 
+ * The data is then read out of this fixed width structure into a String[] at the time it is written to a temp file for the result by the
+ * {@link ResultStoreStream} class.
  *
  */
 public class ResultStore {
 
-	private static Logger log = LoggerFactory.getLogger(ResultStore.class);
+    private static Logger log = LoggerFactory.getLogger(ResultStore.class);
 
-	private List<ColumnMeta> columns;
-	int rowWidth;
-	private int numRows;
-	
-	private static final ColumnMeta PATIENT_ID_COLUMN_META = new ColumnMeta().setColumnOffset(0).setName("PatientId").setWidthInBytes(Integer.BYTES);
-	byte[] resultArray;
-	
-	/**
-	 * 
-	 * @param resultId The result id here is only used for logging
-	 * @param columns The ColumnMeta entries involed in the result, these are used to calculate rowWidth
-	 * @param ids The subject ids for in the current batch of the result
-	 * @throws NotEnoughMemoryException If the size of available heap cannot support a byte array of size (rowWidth x numRows)
-	 */
-	public ResultStore(String resultId, List<ColumnMeta> columns, TreeSet<Integer> ids) throws NotEnoughMemoryException {
-		this.columns = new ArrayList<ColumnMeta>();
-		this.numRows = ids.size();
-		this.getColumns().add(PATIENT_ID_COLUMN_META);
-		int rowWidth = Integer.BYTES;
-		for(ColumnMeta column : columns) {
-			column.setColumnOffset(rowWidth);
-			rowWidth += column.getWidthInBytes();
-			this.getColumns().add(column);
-		}
-		this.rowWidth = rowWidth;
-		if(1L * this.rowWidth * this.getNumRows() > Integer.MAX_VALUE) {
-			throw new ResultSetTooLargeException((1L * this.rowWidth * this.getNumRows())/(Integer.MAX_VALUE/2));
-		}
-		try {
-			log.info("Allocating result array : " + resultId);
-			resultArray = new byte[this.rowWidth * this.getNumRows()];
-		} catch(Error e) {
-			throw new NotEnoughMemoryException();			
-		}
-		log.info("Store created for " + this.getNumRows() + " rows and " + columns.size() + " columns ");
-		int x = 0;
-		for(Integer id : ids) {
-			writeField(0,x++,ByteBuffer.allocate(Integer.BYTES).putInt(id).array());
-		}
-	}
+    private List<OutputColumn> columns;
+    int rowWidth;
+    private int numRows;
 
-	/**
-	 * Copies fieldValue into the resultArray of this instance using System.arraycopy
-	 * @param column
-	 * @param row
-	 * @param fieldValue
-	 */
-	public void writeField(int column, int row, byte[] fieldValue) {
-		int offset = getFieldOffset(row,column);
-		try {
-			System.arraycopy(fieldValue, 0, resultArray, offset, fieldValue.length);
-		}catch(Exception e) {
-			log.info("Exception caught writing field : " + column + ", " + row + " : " + fieldValue.length + " bytes into result at offset " + offset + " of " + resultArray.length);
-			throw e;
-		}
-	}
+    private static final OutputColumn PATIENT_ID_COLUMN_META = new OutputColumn(new SummaryColumnMeta().setName("PatientId"), 0);
+    byte[] resultArray;
 
-	/**
-	 * Finds the resultArray offset of the passed in row and column
-	 * @param row
-	 * @param column
-	 * @return
-	 */
-	private int getFieldOffset(int row, int column) {
-		int rowOffset = row*rowWidth;
-		int columnOffset = getColumns().get(column).getColumnOffset();
-		return rowOffset + columnOffset;
-	}
+    /**
+     * 
+     * @param resultId The result id here is only used for logging
+     * @param columns The ColumnMeta entries involed in the result, these are used to calculate rowWidth
+     * @param ids The subject ids for in the current batch of the result
+     * @throws NotEnoughMemoryException If the size of available heap cannot support a byte array of size (rowWidth x numRows)
+     */
+    public ResultStore(String resultId, List<SummaryColumnMeta> columns, TreeSet<Integer> ids) throws NotEnoughMemoryException {
+        this.columns = new ArrayList<>();
+        this.numRows = ids.size();
+        this.getColumns().add(PATIENT_ID_COLUMN_META);
+        int rowWidth = Integer.BYTES;
+        for (SummaryColumnMeta column : columns) {
+            OutputColumn outputColumn = new OutputColumn(column, rowWidth);
+            this.getColumns().add(outputColumn);
+            rowWidth += column.getWidthInBytes();
+        }
+        this.rowWidth = rowWidth;
+        if (1L * this.rowWidth * this.getNumRows() > Integer.MAX_VALUE) {
+            throw new ResultSetTooLargeException((1L * this.rowWidth * this.getNumRows()) / (Integer.MAX_VALUE / 2));
+        }
+        try {
+            log.info("Allocating result array : " + resultId);
+            resultArray = new byte[this.rowWidth * this.getNumRows()];
+        } catch (Error e) {
+            throw new NotEnoughMemoryException();
+        }
+        log.info("Store created for " + this.getNumRows() + " rows and " + columns.size() + " columns ");
+        int x = 0;
+        for (Integer id : ids) {
+            writeField(0, x++, ByteBuffer.allocate(Integer.BYTES).putInt(id).array());
+        }
+    }
 
-	ByteBuffer wrappedResultArray;
-	/**
-	 * Populate 
-	 * 
-	 * @param rowNumber
-	 * @param row
-	 * @throws IOException
-	 */
-	public void readRowIntoStringArray(int rowNumber, int[] columnWidths, String[] row) {
-		if(wrappedResultArray == null) {
-			wrappedResultArray = ByteBuffer.wrap(resultArray);
-		}
-		row[0] = wrappedResultArray.getInt(getFieldOffset(rowNumber, 0)) + "";
-		
-		stringifyRow(rowNumber, columnWidths, row);
-	}
+    /**
+     * Copies fieldValue into the resultArray of this instance using System.arraycopy
+     * @param column
+     * @param row
+     * @param fieldValue
+     */
+    public void writeField(int column, int row, byte[] fieldValue) {
+        int offset = getFieldOffset(row, column);
+        try {
+            System.arraycopy(fieldValue, 0, resultArray, offset, fieldValue.length);
+        } catch (Exception e) {
+            log.info(
+                "Exception caught writing field : " + column + ", " + row + " : " + fieldValue.length + " bytes into result at offset "
+                    + offset + " of " + resultArray.length
+            );
+            throw e;
+        }
+    }
 
-	/**
-	 * Copy each field of a single row from the resultArray into a String[] to be written out to the CSV
-	 * 
-	 * @param rowNumber row number to copy
-	 * @param row String[] to populate with field values
-	 * @param columnBuffers a set of buffers corresponding to each column where each buffer is {@link ColumnMeta.widthInBytes} bytes
-	 */
-	private void stringifyRow(int rowNumber, int[] columnWidths, String[] row) {
-		for(int x = 1;x<row.length;x++) {
-			ColumnMeta columnMeta = getColumns().get(x);
-			int fieldOffset = getFieldOffset(rowNumber, x);
-			if(columnMeta.isCategorical()) {
-				stringifyString(row, columnWidths, x, fieldOffset);
-			} else {
-				stringifyDouble(row, x, fieldOffset);
-			}
-		}
-	}
+    /**
+     * Finds the resultArray offset of the passed in row and column
+     * @param row
+     * @param column
+     * @return
+     */
+    private int getFieldOffset(int row, int column) {
+        int rowOffset = row * rowWidth;
+        int columnOffset = getColumns().get(column).columnOffset();
+        return rowOffset + columnOffset;
+    }
 
-	DecimalFormat decimalFormat = new DecimalFormat("########.####");
-	private void stringifyDouble(String[] row, int x, int fieldOffset) {
-		row[x] = Double.valueOf(wrappedResultArray.getDouble(fieldOffset)).toString();
-	}
+    ByteBuffer wrappedResultArray;
 
-	private void stringifyString(String[] row, int[] columnWidths, int x, int fieldOffset) {
-		row[x] = new String(Arrays.copyOfRange(resultArray, fieldOffset, fieldOffset + columnWidths[x])).trim();
-	}
+    /**
+     * Populate
+     * 
+     * @param rowNumber
+     * @param row
+     * @throws IOException
+     */
+    public void readRowIntoStringArray(int rowNumber, int[] columnWidths, String[] row) {
+        if (wrappedResultArray == null) {
+            wrappedResultArray = ByteBuffer.wrap(resultArray);
+        }
+        row[0] = wrappedResultArray.getInt(getFieldOffset(rowNumber, 0)) + "";
 
-	public int getNumRows() {
-		return numRows;
-	}
+        stringifyRow(rowNumber, columnWidths, row);
+    }
 
-	public List<ColumnMeta> getColumns() {
-		return columns;
-	}
+    /**
+     * Copy each field of a single row from the resultArray into a String[] to be written out to the CSV
+     * 
+     * @param rowNumber row number to copy
+     * @param row String[] to populate with field values
+     * @param columnBuffers a set of buffers corresponding to each column where each buffer is {@link SummaryColumnMeta.widthInBytes} bytes
+     */
+    private void stringifyRow(int rowNumber, int[] columnWidths, String[] row) {
+        for (int x = 1; x < row.length; x++) {
+            SummaryColumnMeta columnMeta = getColumns().get(x).columnMeta();
+            int fieldOffset = getFieldOffset(rowNumber, x);
+            if (columnMeta.isCategorical()) {
+                stringifyString(row, columnWidths, x, fieldOffset);
+            } else {
+                stringifyDouble(row, x, fieldOffset);
+            }
+        }
+    }
+
+    DecimalFormat decimalFormat = new DecimalFormat("########.####");
+
+    private void stringifyDouble(String[] row, int x, int fieldOffset) {
+        row[x] = Double.valueOf(wrappedResultArray.getDouble(fieldOffset)).toString();
+    }
+
+    private void stringifyString(String[] row, int[] columnWidths, int x, int fieldOffset) {
+        row[x] = new String(Arrays.copyOfRange(resultArray, fieldOffset, fieldOffset + columnWidths[x])).trim();
+    }
+
+    public int getNumRows() {
+        return numRows;
+    }
+
+    public List<OutputColumn> getColumns() {
+        return columns;
+    }
 }

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/ResultStoreStream.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/ResultStoreStream.java
@@ -4,6 +4,8 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.io.CsvWriter;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.io.ResultWriter;
 
@@ -11,119 +13,120 @@ import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 
 public class ResultStoreStream extends InputStream {
 
-	private ResultWriter writer;
-	private InputStream in;
-	private int value;
-	private boolean streamIsClosed = false;
-	private int numRows;
-	private String[] originalHeader;
+    private ResultWriter writer;
+    private InputStream in;
+    private int value;
+    private boolean streamIsClosed = false;
+    private int numRows;
+    private String[] originalHeader;
 
-	public ResultStoreStream(String[] header, ResultWriter writer) throws IOException {
-		this.writer = writer;
-		this.originalHeader = header;
-		writeHeader(this.originalHeader);
-		numRows = 0;
-	}
+    public ResultStoreStream(String[] header, ResultWriter writer) throws IOException {
+        this.writer = writer;
+        this.originalHeader = header;
+        writeHeader(this.originalHeader);
+        numRows = 0;
+    }
 
-	private void writeHeader(String[] header) {
-		writer.writeHeader(header);
-	}
+    private void writeHeader(String[] header) {
+        writer.writeHeader(header);
+    }
 
-	public void appendResultStore(ResultStore results) {
-		int batchSize = 100;
-		List<String[]> entries = new ArrayList<>(batchSize);
-		for(int x = 0;x<batchSize;x++) {
-			entries.add(new String[results.getColumns().size()]);
-		}
-		writeResultsToTempFile(results, batchSize, entries);
-	}
+    public void appendResultStore(ResultStore results) {
+        int batchSize = 100;
+        List<String[]> entries = new ArrayList<>(batchSize);
+        for (int x = 0; x < batchSize; x++) {
+            entries.add(new String[results.getColumns().size()]);
+        }
+        writeResultsToTempFile(results, batchSize, entries);
+    }
 
-	/**
-	 * A more compact method to append data to the temp file without making assumptions about the composition.
-	 * @param entries
-	 */
-	public void appendResults(List<String[]> entries) {
-		writer.writeEntity(entries);
-	}
-	/**
-	 * Appending data to the writer that supports multiple values per patient/variable combination
-	 */
-	public void appendMultiValueResults(List<List<List<String>>> entries) {
-		writer.writeMultiValueEntity(entries);
-	}
+    /**
+     * A more compact method to append data to the temp file without making assumptions about the composition.
+     * @param entries
+     */
+    public void appendResults(List<String[]> entries) {
+        writer.writeEntity(entries);
+    }
 
-	private List<String[]> writeResultsToTempFile(ResultStore results, int batchSize,
-			List<String[]> entries) {
-		
-		List<ColumnMeta> columns = results.getColumns();
-		int[] columnWidths = new int[columns.size()];
-		for(int x = 0;x<columns.size();x++) {
-			columnWidths[x] = columns.get(x).getWidthInBytes();
-		}
+    /**
+     * Appending data to the writer that supports multiple values per patient/variable combination
+     */
+    public void appendMultiValueResults(List<List<List<String>>> entries) {
+        writer.writeMultiValueEntity(entries);
+    }
 
-		for(int x = 0;x<(results.getNumRows());x+=batchSize) {
-			int rowsInBatch = Math.min(batchSize, results.getNumRows() - x);
-			for(int y = 0;y<rowsInBatch;y++) {
-				results.readRowIntoStringArray(y+x, columnWidths, entries.get(y));
-			}
-			if(rowsInBatch < batchSize) {
-				entries = entries.subList(0, rowsInBatch);
-			}
-			writer.writeEntity(entries);
-			numRows += rowsInBatch;
-		}
-		return entries;
-	}
+    private List<String[]> writeResultsToTempFile(ResultStore results, int batchSize, List<String[]> entries) {
 
-	public void close() {
-		try {
-			in.close();
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-	}
+        List<OutputColumn> columns = results.getColumns();
+        int[] columnWidths = new int[columns.size()];
+        for (int x = 0; x < columns.size(); x++) {
+            columnWidths[x] = columns.get(x).columnMeta().getWidthInBytes();
+        }
 
-	public void open() {
-		try {
-			in = new BufferedInputStream(new FileInputStream(writer.getFile().getAbsolutePath()), 1024 * 1024 * 8);
-			streamIsClosed = false;
-		} catch (FileNotFoundException e) {
-			throw new RuntimeException("temp file for result not found : " + writer.getFile().getAbsolutePath());
-		}
+        for (int x = 0; x < (results.getNumRows()); x += batchSize) {
+            int rowsInBatch = Math.min(batchSize, results.getNumRows() - x);
+            for (int y = 0; y < rowsInBatch; y++) {
+                results.readRowIntoStringArray(y + x, columnWidths, entries.get(y));
+            }
+            if (rowsInBatch < batchSize) {
+                entries = entries.subList(0, rowsInBatch);
+            }
+            writer.writeEntity(entries);
+            numRows += rowsInBatch;
+        }
+        return entries;
+    }
+
+    public void close() {
+        try {
+            in.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void open() {
+        try {
+            in = new BufferedInputStream(new FileInputStream(writer.getFile().getAbsolutePath()), 1024 * 1024 * 8);
+            streamIsClosed = false;
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException("temp file for result not found : " + writer.getFile().getAbsolutePath());
+        }
     }
 
 
 
-	@Override
-	public int read() throws IOException {
-		if(streamIsClosed) {
-			return -1;
-		}
-		value = in.read();
-		if(value == -1) {
-			in.close();
-			streamIsClosed = true;
-		}
-		return value;
-	}
+    @Override
+    public int read() throws IOException {
+        if (streamIsClosed) {
+            return -1;
+        }
+        value = in.read();
+        if (value == -1) {
+            in.close();
+            streamIsClosed = true;
+        }
+        return value;
+    }
 
-	public int getNumRows() {
-		return numRows;
-	}
+    public int getNumRows() {
+        return numRows;
+    }
 
-	public long estimatedSize() {
-		return writer.getFile().length();
-	}
+    public long estimatedSize() {
+        return writer.getFile().length();
+    }
 
-	public void closeWriter() {
-		writer.close();
-	}
+    public void closeWriter() {
+        writer.close();
+    }
 
-	public File getFile() {
-		return writer.getFile();
-	}
-	public Path getTempFilePath() {
-		return Path.of(getFile().getAbsolutePath());
-	}
+    public File getFile() {
+        return writer.getFile();
+    }
+
+    public Path getTempFilePath() {
+        return Path.of(getFile().getAbsolutePath());
+    }
 
 }

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/util/UserRequestContext.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/util/UserRequestContext.java
@@ -1,0 +1,24 @@
+package edu.harvard.hms.dbmi.avillach.hpds.processing.util;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+@Component
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+// Or simply use the shortcut: @RequestScope
+public class UserRequestContext {
+    private List<String> userConsents = List.of();
+
+    public List<String> getUserConsents() {
+        return userConsents;
+    }
+
+    public UserRequestContext setUserConsents(List<String> userConsents) {
+        this.userConsents = userConsents;
+        return this;
+    }
+}

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/util/UserRequestContext.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/util/UserRequestContext.java
@@ -1,15 +1,12 @@
 package edu.harvard.hms.dbmi.avillach.hpds.processing.util;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.annotation.RequestScope;
 
 import java.util.List;
 
 @Component
-@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
-// Or simply use the shortcut: @RequestScope
+@RequestScope
 public class UserRequestContext {
     private List<String> userConsents = List.of();
 

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3Processor.java
@@ -27,10 +27,10 @@ public class CountV3Processor implements HpdsV3Processor {
 
     private final QueryExecutor queryExecutor;
 
-    private final PhenotypicObservationStore phenotypicObservationStore;
+    private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     @Autowired
-    public CountV3Processor(QueryExecutor queryExecutor, PhenotypicObservationStore phenotypicObservationStore) {
+    public CountV3Processor(QueryExecutor queryExecutor, PartitionedPhenotypicObservationStore phenotypicObservationStore) {
         this.queryExecutor = queryExecutor;
         this.phenotypicObservationStore = phenotypicObservationStore;
     }
@@ -105,16 +105,13 @@ public class CountV3Processor implements HpdsV3Processor {
     }
 
     /**
-     * Returns a separate count for each field in the requiredFields and categoryFilters query.
-     * <p>
-     * The v3 query lets a user add multiple filters on the same variable (e.g. sex=male OR sex=female). Filters are grouped by concept path
-     * so each variable produces exactly one entry rather than later filters overwriting earlier ones.
-     * <p>
-     * A cross count reports each concept's distribution across the cohort. A category is included when it has members in the cohort, OR when
-     * it was explicitly named ("called out") by a value filter. This means a value filter never hides cohort members that arrived via an OR
-     * branch on another concept (sex=male OR age-required still shows females that have an age), while a value the user specifically asked
-     * for is always shown even when its cohort count is zero. Categories that are neither called out nor present in the cohort are omitted,
-     * so AND-narrowed concepts do not sprout empty bars.
+     * Returns a separate count for each field in the requiredFields and categoryFilters query. <p> The v3 query lets a user add multiple
+     * filters on the same variable (e.g. sex=male OR sex=female). Filters are grouped by concept path so each variable produces exactly one
+     * entry rather than later filters overwriting earlier ones. <p> A cross count reports each concept's distribution across the cohort. A
+     * category is included when it has members in the cohort, OR when it was explicitly named ("called out") by a value filter. This means
+     * a value filter never hides cohort members that arrived via an OR branch on another concept (sex=male OR age-required still shows
+     * females that have an age), while a value the user specifically asked for is always shown even when its cohort count is zero.
+     * Categories that are neither called out nor present in the cohort are omitted, so AND-narrowed concepts do not sprout empty bars.
      *
      * @param query
      * @return a map of categorical data and their counts
@@ -122,8 +119,8 @@ public class CountV3Processor implements HpdsV3Processor {
     public Map<String, Map<String, Integer>> runCategoryCrossCounts(Query query) {
         Set<Integer> baseQueryPatientSet = queryExecutor.getPatientSubsetForQuery(query);
 
-        Map<String, List<PhenotypicFilter>> filtersByConcept = query.allFilters().stream()
-            .filter(this::isCategoryCrossCountFilter).collect(Collectors.groupingBy(PhenotypicFilter::conceptPath));
+        Map<String, List<PhenotypicFilter>> filtersByConcept = query.allFilters().stream().filter(this::isCategoryCrossCountFilter)
+            .collect(Collectors.groupingBy(PhenotypicFilter::conceptPath));
 
         Map<String, Map<String, Integer>> categoryCounts = new TreeMap<>();
         for (Map.Entry<String, List<PhenotypicFilter>> entry : filtersByConcept.entrySet()) {
@@ -164,12 +161,11 @@ public class CountV3Processor implements HpdsV3Processor {
     }
 
     /**
-     * Returns the distribution of observed values for each continuous concept in the query.
-     * <p>
-     * A continuous concept reports the distribution of every observed value across the cohort. Each filter's min/max only constrains the
-     * cohort (handled by the query executor); it does not limit which values are shown. So a range filter never hides cohort members that
-     * arrived via an OR branch on another concept (age&gt;50 OR sex=male still shows the younger ages of the OR'd males), and multiple range
-     * filters on the same concept collapse to one entry since every patient is counted once from the cube.
+     * Returns the distribution of observed values for each continuous concept in the query. <p> A continuous concept reports the
+     * distribution of every observed value across the cohort. Each filter's min/max only constrains the cohort (handled by the query
+     * executor); it does not limit which values are shown. So a range filter never hides cohort members that arrived via an OR branch on
+     * another concept (age&gt;50 OR sex=male still shows the younger ages of the OR'd males), and multiple range filters on the same
+     * concept collapse to one entry since every patient is counted once from the cube.
      *
      * @param query
      * @return a map of numerical data and their counts
@@ -177,8 +173,8 @@ public class CountV3Processor implements HpdsV3Processor {
     public Map<String, Map<Double, Integer>> runContinuousCrossCounts(Query query) {
         Set<Integer> baseQueryPatientSet = queryExecutor.getPatientSubsetForQuery(query);
 
-        Set<String> conceptPaths = query.allFilters().stream().filter(this::isContinuousCrossCountFilter)
-            .map(PhenotypicFilter::conceptPath).collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<String> conceptPaths = query.allFilters().stream().filter(this::isContinuousCrossCountFilter).map(PhenotypicFilter::conceptPath)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Map<String, Map<Double, Integer>> conceptMap = new TreeMap<>();
         for (String conceptPath : conceptPaths) {
@@ -197,8 +193,7 @@ public class CountV3Processor implements HpdsV3Processor {
     }
 
     private boolean isContinuousCrossCountFilter(PhenotypicFilter phenotypicFilter) {
-        return Optional.ofNullable(queryExecutor.getDictionary().get(phenotypicFilter.conceptPath()))
-            .map(meta -> !meta.isCategorical())
+        return Optional.ofNullable(queryExecutor.getDictionary().get(phenotypicFilter.conceptPath())).map(meta -> !meta.isCategorical())
             .orElse(false);
     }
 
@@ -230,18 +225,5 @@ public class CountV3Processor implements HpdsV3Processor {
             response.put("message", "No variant filters were supplied, so no query was run.");
         }
         return response;
-    }
-
-    public PatientAndConceptCount runPatientAndConceptCount(Query incomingQuery) {
-        log.info("Starting Patient and Concept Count query {}", incomingQuery.picsureId());
-        log.info("Calculating available concepts");
-        long concepts = incomingQuery.select().stream().map(phenotypicObservationStore::getCube).filter(Optional::isPresent).count();
-        log.info("Calculating patient counts");
-        int patients = runCounts(incomingQuery);
-        PatientAndConceptCount patientAndConceptCount = new PatientAndConceptCount();
-        patientAndConceptCount.setConceptCount(concepts);
-        patientAndConceptCount.setPatientCount(patients);
-        log.info("Completed Patient and Concept Count query {}", incomingQuery.picsureId());
-        return patientAndConceptCount;
     }
 }

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/MultiValueQueryV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/MultiValueQueryV3Processor.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.KeyAndValue;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.PhenoCube;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,14 +27,15 @@ public class MultiValueQueryV3Processor implements HpdsV3Processor {
     private final int idBatchSize;
     private final QueryExecutor queryExecutor;
 
-    private final PhenotypicObservationStore phenotypicObservationStore;
+    private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     private static final Logger log = LoggerFactory.getLogger(MultiValueQueryV3Processor.class);
 
 
     @Autowired
     public MultiValueQueryV3Processor(
-        QueryExecutor queryExecutor, PhenotypicObservationStore phenotypicObservationStore, @Value("${ID_BATCH_SIZE:0}") int idBatchSize
+        QueryExecutor queryExecutor, PartitionedPhenotypicObservationStore phenotypicObservationStore,
+        @Value("${ID_BATCH_SIZE:0}") int idBatchSize
     ) {
         this.queryExecutor = queryExecutor;
         this.idBatchSize = idBatchSize;
@@ -74,8 +76,8 @@ public class MultiValueQueryV3Processor implements HpdsV3Processor {
 
     private Map<String, Map<Integer, List<String>>> buildResult(Query query, TreeSet<Integer> ids) {
         ConcurrentHashMap<String, Map<Integer, List<String>>> pathToPatientToValueMap = new ConcurrentHashMap<>();
-        List<ColumnMeta> columns = query.select().stream().map(queryExecutor.getDictionary()::get).filter(Objects::nonNull).toList();
-        List<String> paths = columns.stream().map(ColumnMeta::getName).collect(Collectors.toList());
+        List<SummaryColumnMeta> columns = query.select().stream().map(queryExecutor.getDictionary()::get).filter(Objects::nonNull).toList();
+        List<String> paths = columns.stream().map(SummaryColumnMeta::getName).collect(Collectors.toList());
         int columnCount = paths.size() + 1;
 
         ArrayList<Integer> columnIndex = queryExecutor.useResidentCubesFirst(paths, columnCount);

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
@@ -1,0 +1,152 @@
+package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
+
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.PhenoCube;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.PhenotypeMetaStore;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class PartitionedPhenotypicObservationStore {
+
+    private static final Logger log = LoggerFactory.getLogger(PartitionedPhenotypicObservationStore.class);
+
+    private final UserRequestContext userRequestContext;
+
+    private final Map<String, PhenotypicObservationStore> phenotypicPartitions;
+
+    @Autowired
+    public PartitionedPhenotypicObservationStore(
+        UserRequestContext userRequestContext, @Value("${HPDS_DATA_DIRECTORY:/opt/local/hpds/}") String hpdsDataDirectory
+    ) {
+        this.userRequestContext = userRequestContext;
+
+        try (Stream<Path> stream = Files.walk(Path.of(hpdsDataDirectory))) {
+            List<Path> subdirectories = stream.filter(Files::isDirectory)
+                .filter(subdirectory -> !subdirectory.equals(Path.of(hpdsDataDirectory))).collect(Collectors.toList());
+
+            Map<String, PhenotypicObservationStore> phenotypicPartitions = new HashMap<>();
+            Set<PhenotypeMetaStore> allMetaStores = new HashSet<>();
+
+            for (Path subdirectory : subdirectories) {
+                String partitionName = subdirectory.getFileName().toString();
+                PhenotypeMetaStore phenotypeMetaStore = new PhenotypeMetaStore(subdirectory.toString(), 500);
+                allMetaStores.add(phenotypeMetaStore);
+                PhenotypicObservationStore phenotypicObservationStore =
+                    new PhenotypicObservationStore(phenotypeMetaStore, subdirectory.toString(), 1000);
+                phenotypicPartitions.put(partitionName, phenotypicObservationStore);
+            }
+
+            this.phenotypicPartitions = Map.copyOf(phenotypicPartitions);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Set<Integer> getKeysForRange(String conceptPath, Double min, Double max) {
+        // todo: disallow this by default
+        if (userRequestContext.getUserConsents().isEmpty()) {
+            Set<Integer> patientIds = phenotypicPartitions.values().stream()
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForRange(conceptPath, min, max).stream())
+                .collect(Collectors.toSet());
+            return patientIds;
+        } else {
+            Set<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForRange(conceptPath, min, max).stream())
+                .collect(Collectors.toSet());
+            return patientIds;
+        }
+    }
+
+    public Set<Integer> getKeysForValues(String conceptPath, Collection<String> values) {
+        // todo: disallow this by default
+        if (userRequestContext.getUserConsents().isEmpty()) {
+            Set<Integer> patientIds = phenotypicPartitions.values().stream()
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForValues(conceptPath, values).stream())
+                .collect(Collectors.toSet());
+            return patientIds;
+        } else {
+            Set<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getKeysForValues(conceptPath, values).stream())
+                .collect(Collectors.toSet());
+            return patientIds;
+        }
+    }
+
+    public List<Integer> getAllKeys(String conceptPath) {
+        // todo: disallow this by default
+        if (userRequestContext.getUserConsents().isEmpty()) {
+            List<Integer> patientIds = phenotypicPartitions.values().stream()
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getAllKeys(conceptPath).stream())
+                .collect(Collectors.toList());
+            return patientIds;
+        } else {
+            List<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getAllKeys(conceptPath).stream())
+                .collect(Collectors.toList());
+            return patientIds;
+        }
+    }
+
+    public Optional<PhenoCube<?>> getCube(String path) {
+        throw new RuntimeException("Not implemented");
+    }
+
+    public Set<String> getCachedKeys() {
+        // todo: figure out a better solution for this
+        return phenotypicPartitions.values().stream().findFirst().orElseThrow().getCachedKeys();
+    }
+
+    public Set<Integer> getPatientIds() {
+        // todo: disallow this by default
+        if (userRequestContext.getUserConsents().isEmpty()) {
+            Set<Integer> patientIds = phenotypicPartitions.values().stream()
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getPatientIds().stream()).collect(Collectors.toSet());
+            return patientIds;
+        } else {
+            Set<Integer> patientIds = userRequestContext.getUserConsents().stream().map(phenotypicPartitions::get)
+                .flatMap(phenotypicObservationStore -> phenotypicObservationStore.getPatientIds().stream()).collect(Collectors.toSet());
+            return patientIds;
+        }
+    }
+
+    public Set<String> getChildConceptPaths(String s) {
+        throw new RuntimeException("Not implemented yet");
+    }
+
+    @Cacheable("PartitionedPhenotypicObservationStore.getMetaStore")
+    public Map<String, SummaryColumnMeta> getMetaStore() {
+        Map<String, SummaryColumnMeta> mergedColumnMeta = new HashMap<>();
+        List<Map<String, ColumnMeta>> allPartitionMetaStores =
+            phenotypicPartitions.values().stream().map(PhenotypicObservationStore::getMetaStore).collect(Collectors.toList());
+        for (Map<String, ColumnMeta> metaStore : allPartitionMetaStores) {
+            for (Map.Entry<String, ColumnMeta> stringColumnMetaEntry : metaStore.entrySet()) {
+                SummaryColumnMeta summaryColumnMeta = mergedColumnMeta.get(stringColumnMetaEntry.getKey());
+                if (summaryColumnMeta == null) {
+                    summaryColumnMeta = new SummaryColumnMeta(stringColumnMetaEntry.getValue());
+                } else {
+                    summaryColumnMeta = summaryColumnMeta.merge(stringColumnMetaEntry.getValue());
+                }
+                mergedColumnMeta.put(stringColumnMetaEntry.getKey(), summaryColumnMeta);
+            }
+        }
+        return mergedColumnMeta;
+    }
+
+
+}

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PartitionedPhenotypicObservationStore.java
@@ -36,17 +36,15 @@ public class PartitionedPhenotypicObservationStore {
     ) {
         this.userRequestContext = userRequestContext;
 
-        try (Stream<Path> stream = Files.walk(Path.of(hpdsDataDirectory))) {
+        try (Stream<Path> stream = Files.list(Path.of(hpdsDataDirectory))) {
             List<Path> subdirectories = stream.filter(Files::isDirectory)
                 .filter(subdirectory -> !subdirectory.equals(Path.of(hpdsDataDirectory))).collect(Collectors.toList());
 
             Map<String, PhenotypicObservationStore> phenotypicPartitions = new HashMap<>();
-            Set<PhenotypeMetaStore> allMetaStores = new HashSet<>();
 
             for (Path subdirectory : subdirectories) {
                 String partitionName = subdirectory.getFileName().toString();
                 PhenotypeMetaStore phenotypeMetaStore = new PhenotypeMetaStore(subdirectory.toString(), 500);
-                allMetaStores.add(phenotypeMetaStore);
                 PhenotypicObservationStore phenotypicObservationStore =
                     new PhenotypicObservationStore(phenotypeMetaStore, subdirectory.toString(), 1000);
                 phenotypicPartitions.put(partitionName, phenotypicObservationStore);
@@ -140,7 +138,7 @@ public class PartitionedPhenotypicObservationStore {
                 if (summaryColumnMeta == null) {
                     summaryColumnMeta = new SummaryColumnMeta(stringColumnMetaEntry.getValue());
                 } else {
-                    summaryColumnMeta = summaryColumnMeta.merge(stringColumnMetaEntry.getValue());
+                    summaryColumnMeta = summaryColumnMeta.merge(new SummaryColumnMeta(stringColumnMetaEntry.getValue()));
                 }
                 mergedColumnMeta.put(stringColumnMetaEntry.getKey(), summaryColumnMeta);
             }

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicFilterValidator.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicFilterValidator.java
@@ -1,6 +1,6 @@
 package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 
-import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.AuthorizationFilter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicFilter;
 import org.slf4j.Logger;
@@ -14,7 +14,7 @@ public class PhenotypicFilterValidator {
 
     private static final Logger log = LoggerFactory.getLogger(PhenotypicFilterValidator.class);
 
-    public void validate(PhenotypicFilter phenotypicFilter, Map<String, ColumnMeta> metaStore) {
+    public void validate(PhenotypicFilter phenotypicFilter, Map<String, SummaryColumnMeta> metaStore) {
         switch (phenotypicFilter.phenotypicFilterType()) {
             case FILTER -> validateFilterFilter(phenotypicFilter, metaStore);
             case REQUIRED -> validateRequiredFilter(phenotypicFilter, metaStore);
@@ -22,7 +22,7 @@ public class PhenotypicFilterValidator {
         }
     }
 
-    public void validate(AuthorizationFilter authorizationFilter, Map<String, ColumnMeta> metaStore) {
+    public void validate(AuthorizationFilter authorizationFilter, Map<String, SummaryColumnMeta> metaStore) {
         if (authorizationFilter.values() == null || authorizationFilter.values().isEmpty()) {
             throw new IllegalArgumentException("AuthorizationFilter values cannot be null or empty");
         }
@@ -36,7 +36,7 @@ public class PhenotypicFilterValidator {
         }
     }
 
-    private void validateFilterFilter(PhenotypicFilter phenotypicFilter, Map<String, ColumnMeta> metaStore) {
+    private void validateFilterFilter(PhenotypicFilter phenotypicFilter, Map<String, SummaryColumnMeta> metaStore) {
         if (
             (phenotypicFilter.min() != null || phenotypicFilter.max() != null) && phenotypicFilter.values() != null
                 && !phenotypicFilter.values().isEmpty()
@@ -53,7 +53,7 @@ public class PhenotypicFilterValidator {
         }
     }
 
-    private void validateRequiredFilter(PhenotypicFilter phenotypicFilter, Map<String, ColumnMeta> metaStore) {
+    private void validateRequiredFilter(PhenotypicFilter phenotypicFilter, Map<String, SummaryColumnMeta> metaStore) {
         if (phenotypicFilter.min() != null || phenotypicFilter.max() != null || phenotypicFilter.values() != null) {
             throw new IllegalArgumentException(
                 "Required filter with concept path " + phenotypicFilter.conceptPath() + " cannot have categorical values or min/max set"

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicObservationStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicObservationStore.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ExecutionException;
 /**
  * Class representing a store for phenotypic observations. The store manages caching of PhenoCube objects.
  */
-@Component
 public class PhenotypicObservationStore {
 
     private static final Logger log = LoggerFactory.getLogger(PhenotypicObservationStore.class);
@@ -32,13 +31,12 @@ public class PhenotypicObservationStore {
 
     private final PhenotypeMetaStore phenotypeMetaStore;
 
-    @Autowired
     public PhenotypicObservationStore(
         PhenotypeMetaStore phenotypeMetaStore, @Value("${HPDS_DATA_DIRECTORY:/opt/local/hpds/}") String hpdsDataDirectory,
         @Value("${CACHE_SIZE:100}") int cacheSize
     ) {
         this.phenotypeMetaStore = phenotypeMetaStore;
-        this.hpdsDataDirectory = hpdsDataDirectory;
+        this.hpdsDataDirectory = hpdsDataDirectory.endsWith("/") ? hpdsDataDirectory : hpdsDataDirectory + "/";
         phenoCubeCache = CacheBuilder.newBuilder().maximumSize(cacheSize).build(new CacheLoader<>() {
             public PhenoCube<?> load(String key) {
                 return loadPhenoCube(key);
@@ -127,5 +125,13 @@ public class PhenotypicObservationStore {
      */
     public Set<String> getCachedKeys() {
         return phenoCubeCache.asMap().keySet();
+    }
+
+    public Set<Integer> getPatientIds() {
+        return phenotypeMetaStore.getPatientIds();
+    }
+
+    public Map<String, ColumnMeta> getMetaStore() {
+        return phenotypeMetaStore.getMetaStore();
     }
 }

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicObservationStore.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicObservationStore.java
@@ -31,10 +31,8 @@ public class PhenotypicObservationStore {
 
     private final PhenotypeMetaStore phenotypeMetaStore;
 
-    public PhenotypicObservationStore(
-        PhenotypeMetaStore phenotypeMetaStore, @Value("${HPDS_DATA_DIRECTORY:/opt/local/hpds/}") String hpdsDataDirectory,
-        @Value("${CACHE_SIZE:100}") int cacheSize
-    ) {
+    public PhenotypicObservationStore(PhenotypeMetaStore phenotypeMetaStore, String hpdsDataDirectory, int cacheSize) {
+        // todo: reconsider cache size
         this.phenotypeMetaStore = phenotypeMetaStore;
         this.hpdsDataDirectory = hpdsDataDirectory.endsWith("/") ? hpdsDataDirectory : hpdsDataDirectory + "/";
         phenoCubeCache = CacheBuilder.newBuilder().maximumSize(cacheSize).build(new CacheLoader<>() {

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutor.java
@@ -24,9 +24,7 @@ public class PhenotypicQueryExecutor {
     private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     @Autowired
-    public PhenotypicQueryExecutor(
-        PartitionedPhenotypicObservationStore phenotypicObservationStore, UserRequestContext userRequestContext
-    ) {
+    public PhenotypicQueryExecutor(PartitionedPhenotypicObservationStore phenotypicObservationStore) {
         this.phenotypicObservationStore = phenotypicObservationStore;
     }
 

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutor.java
@@ -2,9 +2,11 @@ package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 
 import com.google.common.collect.Sets;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.*;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.PhenotypeMetaStore;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.util.SetUtils;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,13 +21,12 @@ public class PhenotypicQueryExecutor {
 
     private static Logger log = LoggerFactory.getLogger(PhenotypicQueryExecutor.class);
 
-    private final PhenotypeMetaStore phenotypeMetaStore;
-
-    private final PhenotypicObservationStore phenotypicObservationStore;
+    private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     @Autowired
-    public PhenotypicQueryExecutor(PhenotypeMetaStore phenotypeMetaStore, PhenotypicObservationStore phenotypicObservationStore) {
-        this.phenotypeMetaStore = phenotypeMetaStore;
+    public PhenotypicQueryExecutor(
+        PartitionedPhenotypicObservationStore phenotypicObservationStore, UserRequestContext userRequestContext
+    ) {
         this.phenotypicObservationStore = phenotypicObservationStore;
     }
 
@@ -44,7 +45,7 @@ public class PhenotypicQueryExecutor {
             return evaluatePhenotypicClause(authorizedSubquery);
         } else {
             // if there are no phenotypic queries, return all patients
-            return phenotypeMetaStore.getPatientIds();
+            return phenotypicObservationStore.getPatientIds();
         }
     }
 
@@ -72,7 +73,7 @@ public class PhenotypicQueryExecutor {
     }
 
     private Set<Integer> evaluateAnyRecordOfFilter(PhenotypicFilter phenotypicFilter) {
-        Set<String> matchingConcepts = phenotypeMetaStore.getChildConceptPaths(phenotypicFilter.conceptPath());
+        Set<String> matchingConcepts = phenotypicObservationStore.getChildConceptPaths(phenotypicFilter.conceptPath());
         Set<Integer> ids = new TreeSet<>();
         for (String concept : matchingConcepts) {
             ids.addAll(phenotypicObservationStore.getAllKeys(concept));
@@ -139,11 +140,11 @@ public class PhenotypicQueryExecutor {
     }
 
 
-    public Map<String, ColumnMeta> getMetaStore() {
-        return phenotypeMetaStore.getMetaStore();
+    public Map<String, SummaryColumnMeta> getMetaStore() {
+        return phenotypicObservationStore.getMetaStore();
     }
 
     public Set<Integer> getPatientIds() {
-        return phenotypeMetaStore.getPatientIds();
+        return phenotypicObservationStore.getPatientIds();
     }
 }

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryExecutor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryExecutor.java
@@ -7,6 +7,7 @@ import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.VariableVariantMasks;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.VariantMask;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.caching.VariantBucketHolder;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.Filter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.DistributableQuery;
@@ -136,7 +137,7 @@ public class QueryExecutor {
         return phenotypicQueryExecutor.useResidentCubesFirst(paths, columnCount);
     }
 
-    public Map<String, ColumnMeta> getDictionary() {
+    public Map<String, SummaryColumnMeta> getDictionary() {
         return phenotypicQueryExecutor.getMetaStore();
     }
 

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryV3Processor.java
@@ -7,8 +7,10 @@ import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.caching.VariantBucketHol
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.KeyAndValue;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.PhenoCube;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.ResultStore;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,14 +38,18 @@ public class QueryV3Processor implements HpdsV3Processor {
 
     private final QueryExecutor queryExecutor;
 
-    private final PhenotypicObservationStore phenotypicObservationStore;
+    private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
+
+    private final UserRequestContext userRequestContext;
 
     @Autowired
     public QueryV3Processor(
-        QueryExecutor queryExecutor, PhenotypicObservationStore phenotypicObservationStore, @Value("${ID_BATCH_SIZE:0}") int idBatchSize
+        QueryExecutor queryExecutor, PartitionedPhenotypicObservationStore phenotypicObservationStore,
+        UserRequestContext userRequestContext, @Value("${ID_BATCH_SIZE:0}") int idBatchSize
     ) {
         this.queryExecutor = queryExecutor;
         this.phenotypicObservationStore = phenotypicObservationStore;
+        this.userRequestContext = userRequestContext;
         this.idBatchSize = idBatchSize;
     }
 
@@ -64,9 +70,9 @@ public class QueryV3Processor implements HpdsV3Processor {
 
 
     private ResultStore buildResult(AsyncResult result, Query query, TreeSet<Integer> ids) {
-        List<ColumnMeta> columns =
+        List<SummaryColumnMeta> columns =
             query.select().stream().map(queryExecutor.getDictionary()::get).filter(Objects::nonNull).collect(Collectors.toList());
-        List<String> paths = columns.stream().map(ColumnMeta::getName).collect(Collectors.toList());
+        List<String> paths = columns.stream().map(SummaryColumnMeta::getName).collect(Collectors.toList());
         int columnCount = paths.size() + 1;
 
         ArrayList<Integer> columnIndex = queryExecutor.useResidentCubesFirst(paths, columnCount);

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryV3Processor.java
@@ -4,13 +4,11 @@ import com.google.common.collect.Lists;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genomic.VariantUtils;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.VariableVariantMasks;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.caching.VariantBucketHolder;
-import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.KeyAndValue;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.PhenoCube;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.ResultStore;
-import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,16 +38,13 @@ public class QueryV3Processor implements HpdsV3Processor {
 
     private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
-    private final UserRequestContext userRequestContext;
-
     @Autowired
     public QueryV3Processor(
         QueryExecutor queryExecutor, PartitionedPhenotypicObservationStore phenotypicObservationStore,
-        UserRequestContext userRequestContext, @Value("${ID_BATCH_SIZE:0}") int idBatchSize
+        @Value("${ID_BATCH_SIZE:0}") int idBatchSize
     ) {
         this.queryExecutor = queryExecutor;
         this.phenotypicObservationStore = phenotypicObservationStore;
-        this.userRequestContext = userRequestContext;
         this.idBatchSize = idBatchSize;
     }
 

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidator.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidator.java
@@ -1,6 +1,7 @@
 package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +33,7 @@ public class QueryValidator {
     }
 
     public void validate(Query query) {
-        Map<String, ColumnMeta> metaStore = phenotypicQueryExecutor.getMetaStore();
+        Map<String, SummaryColumnMeta> metaStore = phenotypicQueryExecutor.getMetaStore();
 
         if (requireAuthorizationFilter) {
             if (query.authorizationFilters().isEmpty()) {

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/TimeseriesV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/TimeseriesV3Processor.java
@@ -77,11 +77,11 @@ public class TimeseriesV3Processor implements HpdsV3Processor {
         Set<String> exportedConceptPaths = new HashSet<>();
         Collection<String> pathList = queryExecutor.getAllConceptPaths(query);
 
-        addDataForConcepts(pathList, exportedConceptPaths, idList, result, query.getUserConsents());
+        addDataForConcepts(pathList, exportedConceptPaths, idList, result);
     }
 
     private void addDataForConcepts(
-        Collection<String> pathList, Set<String> exportedConceptPaths, Set<Integer> idList, AsyncResult result, List<String> userConsents
+        Collection<String> pathList, Set<String> exportedConceptPaths, Set<Integer> idList, AsyncResult result
     ) {
         for (String conceptPath : pathList) {
             // skip concepts we may already have encountered

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/TimeseriesV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/TimeseriesV3Processor.java
@@ -34,14 +34,14 @@ public class TimeseriesV3Processor implements HpdsV3Processor {
     private final QueryExecutor queryExecutor;
     private final TimeSeriesConversionService conversionService;
 
-    private final PhenotypicObservationStore phenotypicObservationStore;
+    private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     private final int idBatchSize;
 
     @Autowired
     public TimeseriesV3Processor(
-        QueryExecutor queryExecutor, TimeSeriesConversionService conversionService, PhenotypicObservationStore phenotypicObservationStore,
-        @Value("${ID_BATCH_SIZE:0}") int idBatchSize
+        QueryExecutor queryExecutor, TimeSeriesConversionService conversionService,
+        PartitionedPhenotypicObservationStore phenotypicObservationStore, @Value("${ID_BATCH_SIZE:0}") int idBatchSize
     ) {
         this.queryExecutor = queryExecutor;
         this.conversionService = conversionService;
@@ -77,11 +77,11 @@ public class TimeseriesV3Processor implements HpdsV3Processor {
         Set<String> exportedConceptPaths = new HashSet<>();
         Collection<String> pathList = queryExecutor.getAllConceptPaths(query);
 
-        addDataForConcepts(pathList, exportedConceptPaths, idList, result);
+        addDataForConcepts(pathList, exportedConceptPaths, idList, result, query.getUserConsents());
     }
 
     private void addDataForConcepts(
-        Collection<String> pathList, Set<String> exportedConceptPaths, Set<Integer> idList, AsyncResult result
+        Collection<String> pathList, Set<String> exportedConceptPaths, Set<Integer> idList, AsyncResult result, List<String> userConsents
     ) {
         for (String conceptPath : pathList) {
             // skip concepts we may already have encountered

--- a/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/VariantListV3Processor.java
+++ b/processing/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/VariantListV3Processor.java
@@ -41,13 +41,13 @@ public class VariantListV3Processor implements HpdsV3Processor {
     private final QueryExecutor queryExecutor;
     private final ColumnSorter columnSorter;
 
-    private final PhenotypicObservationStore phenotypicObservationStore;
+    private final PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
 
     @Autowired
     public VariantListV3Processor(
         QueryExecutor queryExecutor, GenomicProcessor genomicProcessor, ColumnSorter columnSorter,
-        PhenotypicObservationStore phenotypicObservationStore, @Value("${VCF_EXCERPT_ENABLED:false}") boolean vcfExcerptEnabled,
+        PartitionedPhenotypicObservationStore phenotypicObservationStore, @Value("${VCF_EXCERPT_ENABLED:false}") boolean vcfExcerptEnabled,
         @Value("${AGGREGATE_VCF_EXCERPT_ENABLED:false}") boolean aggregateVcfExcerptEnabled,
         @Value("${ID_CUBE_NAME:NONE}") String idCubeName
     ) {

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/CountV3ProcessorTest.java
@@ -3,6 +3,7 @@ package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.KeyAndValue;
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.PhenoCube;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.ResultType;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Operator;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicFilter;
@@ -35,7 +36,7 @@ class CountV3ProcessorTest {
     private QueryExecutor queryExecutor;
 
     @Mock
-    private PhenotypicObservationStore phenotypicObservationStore;
+    private PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     @BeforeEach
     public void setup() {
@@ -148,12 +149,11 @@ class CountV3ProcessorTest {
         Query query = new Query(List.of(), List.of(), required, List.of(), ResultType.CONTINUOUS_CROSS_COUNT, null, null);
 
         PhenoCube<Double> cube = new PhenoCube<>(conceptPath, Double.class);
-        cube.setSortedByKey(
-            new KeyAndValue[] {new KeyAndValue<>(1, 18.0), new KeyAndValue<>(2, 19.0), new KeyAndValue<>(3, 19.0)}
-        );
+        cube.setSortedByKey(new KeyAndValue[] {new KeyAndValue<>(1, 18.0), new KeyAndValue<>(2, 19.0), new KeyAndValue<>(3, 19.0)});
 
         when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 3));
-        when(queryExecutor.getDictionary()).thenReturn(Map.of(conceptPath, new ColumnMeta().setName(conceptPath).setCategorical(false)));
+        when(queryExecutor.getDictionary())
+            .thenReturn(Map.of(conceptPath, new SummaryColumnMeta().setName(conceptPath).setCategorical(false)));
         when(phenotypicObservationStore.getCube(conceptPath)).thenReturn(java.util.Optional.of(cube));
 
         Map<String, Map<Double, Integer>> crossCounts = countV3Processor.runContinuousCrossCounts(query);
@@ -203,7 +203,7 @@ class CountV3ProcessorTest {
         // Base set is a partial subset of every category, forcing the per-patient counting path.
         // Only patient 1 (male) and patient 4 (female) are in the cohort, so each category count must be exactly 1.
         when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 4));
-        when(queryExecutor.getDictionary()).thenReturn(Map.of(sexPath, new ColumnMeta().setName(sexPath).setCategorical(true)));
+        when(queryExecutor.getDictionary()).thenReturn(Map.of(sexPath, new SummaryColumnMeta().setName(sexPath).setCategorical(true)));
         when(phenotypicObservationStore.getCube(sexPath)).thenReturn(Optional.of(cube));
 
         Map<String, Map<String, Integer>> crossCounts = countV3Processor.runCategoryCrossCounts(query);
@@ -226,7 +226,7 @@ class CountV3ProcessorTest {
         cube.setSortedByKey(new KeyAndValue[] {new KeyAndValue<>(1, 15.0), new KeyAndValue<>(2, 40.0), new KeyAndValue<>(3, 65.0)});
 
         when(queryExecutor.getPatientSubsetForQuery(query)).thenReturn(Set.of(1, 2));
-        when(queryExecutor.getDictionary()).thenReturn(Map.of(agePath, new ColumnMeta().setName(agePath).setCategorical(false)));
+        when(queryExecutor.getDictionary()).thenReturn(Map.of(agePath, new SummaryColumnMeta().setName(agePath).setCategorical(false)));
         when(phenotypicObservationStore.getCube(agePath)).thenReturn(Optional.of(cube));
 
         Map<String, Map<Double, Integer>> crossCounts = countV3Processor.runContinuousCrossCounts(query);

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicFilterValidatorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicFilterValidatorTest.java
@@ -1,6 +1,7 @@
 package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,14 +15,14 @@ class PhenotypicFilterValidatorTest {
 
     private PhenotypicFilterValidator phenotypicFilterValidator;
 
-    private Map<String, ColumnMeta> metaStore;
+    private Map<String, SummaryColumnMeta> metaStore;
 
     @BeforeEach
     public void setup() {
         phenotypicFilterValidator = new PhenotypicFilterValidator();
         metaStore = Map.of(
-            "\\study123\\demographics\\sex\\", new ColumnMeta().setCategorical(true), "\\study123\\demographics\\age\\",
-            new ColumnMeta().setCategorical(false).setMin(0).setMax(130)
+            "\\study123\\demographics\\sex\\", new SummaryColumnMeta().setCategorical(true), "\\study123\\demographics\\age\\",
+            new SummaryColumnMeta().setCategorical(false).setMin(0).setMax(130)
         );
     }
 

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicFilterValidatorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicFilterValidatorTest.java
@@ -22,7 +22,7 @@ class PhenotypicFilterValidatorTest {
         phenotypicFilterValidator = new PhenotypicFilterValidator();
         metaStore = Map.of(
             "\\study123\\demographics\\sex\\", new SummaryColumnMeta().setCategorical(true), "\\study123\\demographics\\age\\",
-            new SummaryColumnMeta().setCategorical(false).setMin(0).setMax(130)
+            new SummaryColumnMeta().setCategorical(false).setMin(0.0).setMax(130.0)
         );
     }
 

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutorTest.java
@@ -3,6 +3,7 @@ package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.ResultType;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.*;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.PhenotypeMetaStore;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,16 +24,13 @@ import static org.mockito.Mockito.*;
 class PhenotypicQueryExecutorTest {
 
     @Mock
-    private PhenotypeMetaStore phenotypeMetaStore;
-
-    @Mock
-    private PhenotypicObservationStore phenotypicObservationStore;
+    private PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     private PhenotypicQueryExecutor phenotypicQueryExecutor;
 
     @BeforeEach
     public void setup() {
-        phenotypicQueryExecutor = new PhenotypicQueryExecutor(phenotypeMetaStore, phenotypicObservationStore);
+        phenotypicQueryExecutor = new PhenotypicQueryExecutor(phenotypicObservationStore, new UserRequestContext());
     }
 
     @Test
@@ -40,7 +38,7 @@ class PhenotypicQueryExecutorTest {
         Query query = new Query(List.of(), List.of(), null, null, ResultType.COUNT, null, null);
 
         Set<Integer> patientIds = Set.of(10, 100, 1000);
-        when(phenotypeMetaStore.getPatientIds()).thenReturn(new TreeSet<>(patientIds));
+        when(phenotypicObservationStore.getPatientIds()).thenReturn(new TreeSet<>(patientIds));
 
         Set<Integer> patientSet = phenotypicQueryExecutor.getPatientSet(query);
         assertEquals(patientIds, patientSet);
@@ -167,7 +165,7 @@ class PhenotypicQueryExecutorTest {
             ResultType.COUNT, null, null
         );
 
-        when(phenotypeMetaStore.getChildConceptPaths("\\open_access-1000Genomes\\"))
+        when(phenotypicObservationStore.getChildConceptPaths("\\open_access-1000Genomes\\"))
             .thenReturn(Set.of(categoricalConceptPath, numericConceptPath));
         List<Integer> numericPatientIds = List.of(2, 3, 5);
         List<Integer> categoricalPatientIds = List.of(10, 100, 1000, 100000);
@@ -193,7 +191,7 @@ class PhenotypicQueryExecutorTest {
             ResultType.COUNT, null, null
         );
 
-        when(phenotypeMetaStore.getChildConceptPaths("\\open_access-1000Genomes\\")).thenReturn(Set.of());
+        when(phenotypicObservationStore.getChildConceptPaths("\\open_access-1000Genomes\\")).thenReturn(Set.of());
 
         Set<Integer> patientSet = phenotypicQueryExecutor.getPatientSet(query);
         assertEquals(Set.of(), patientSet);

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/PhenotypicQueryExecutorTest.java
@@ -30,7 +30,7 @@ class PhenotypicQueryExecutorTest {
 
     @BeforeEach
     public void setup() {
-        phenotypicQueryExecutor = new PhenotypicQueryExecutor(phenotypicObservationStore, new UserRequestContext());
+        phenotypicQueryExecutor = new PhenotypicQueryExecutor(phenotypicObservationStore);
     }
 
     @Test

--- a/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidatorTest.java
+++ b/processing/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/processing/v3/QueryValidatorTest.java
@@ -1,6 +1,7 @@
 package edu.harvard.hms.dbmi.avillach.hpds.processing.v3;
 
 import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.ColumnMeta;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.ResultType;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,14 +28,14 @@ class QueryValidatorTest {
 
     private QueryValidator queryValidator;
 
-    private Map<String, ColumnMeta> metaStore;
+    private Map<String, SummaryColumnMeta> metaStore;
 
 
     @BeforeEach
     public void setup() {
         metaStore = Map.of(
-            "\\study123\\demographics\\sex\\", new ColumnMeta().setCategorical(true), "\\study123\\demographics\\age\\",
-            new ColumnMeta().setCategorical(false).setMin(0).setMax(130)
+            "\\study123\\demographics\\sex\\", new SummaryColumnMeta().setCategorical(true), "\\study123\\demographics\\age\\",
+            new SummaryColumnMeta().setCategorical(false).setMin(0.0).setMax(130.0)
         );
 
         queryValidator = new QueryValidator(phenotypicQueryExecutor, phenotypicFilterValidator, false);

--- a/service/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/service/PicSureV3Service.java
+++ b/service/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/service/PicSureV3Service.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import edu.harvard.dbmi.avillach.domain.*;
 import edu.harvard.dbmi.avillach.util.UUIDv5;
 import edu.harvard.hms.dbmi.avillach.hpds.crypto.Crypto;
+import edu.harvard.hms.dbmi.avillach.hpds.data.phenotype.SummaryColumnMeta;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.audit.AuditAttributes;
 import edu.harvard.dbmi.avillach.logging.AuditEvent;
 import edu.harvard.hms.dbmi.avillach.hpds.data.genotype.InfoColumnMeta;
@@ -167,7 +168,7 @@ public class PicSureV3Service {
         if (searchJson.getQuery() != null) {
             AuditAttributes.putMetadata(httpRequest, "search_term", searchJson.getQuery().toString());
         }
-        Set<Entry<String, ColumnMeta>> allColumns = queryExecutor.getDictionary().entrySet();
+        Set<Entry<String, SummaryColumnMeta>> allColumns = queryExecutor.getDictionary().entrySet();
 
         // Phenotype Values
         Object phenotypeResults = searchJson.getQuery() != null ? allColumns.stream().filter((entry) -> {

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/AuditWiringTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/AuditWiringTest.java
@@ -19,11 +19,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @SpringBootTest
-@TestPropertySource(properties = {
-    "SMALL_JOB_LIMIT=100",
-    "SMALL_TASK_THREADS=2",
-    "LARGE_TASK_THREADS=2",
-})
+@TestPropertySource(properties = {"SMALL_JOB_LIMIT=100", "SMALL_TASK_THREADS=2", "LARGE_TASK_THREADS=2",})
 class AuditWiringTest {
 
     // -- Bean under verification --------------------------------------------------
@@ -81,7 +77,7 @@ class AuditWiringTest {
     @MockBean
     PhenotypicFilterValidator phenotypicFilterValidator;
     @MockBean
-    PhenotypicObservationStore phenotypicObservationStore;
+    PartitionedPhenotypicObservationStore phenotypicObservationStore;
 
     // Shared processing dependencies
     @MockBean

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/v3/QueryServiceTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/service/v3/QueryServiceTest.java
@@ -7,6 +7,7 @@ import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.GenomicFilter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicFilter;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.PhenotypicFilterType;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.v3.AsyncResult;
 import edu.harvard.hms.dbmi.avillach.hpds.service.HpdsApplication;
 import edu.harvard.hms.dbmi.avillach.hpds.service.QueryV3Service;
@@ -16,8 +17,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
@@ -32,10 +35,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @EnableAutoConfiguration
 @SpringBootTest(classes = HpdsApplication.class)
 @ActiveProfiles("integration-test")
+@AutoConfigureMockMvc
 class QueryServiceTest {
 
     @Autowired
     private QueryV3Service queryService;
+
+    @MockitoBean
+    private UserRequestContext userRequestContext;
 
     @BeforeAll
     public static void beforeAll() {

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/CountV3ProcessorIntegrationTest.java
@@ -2,6 +2,7 @@ package edu.harvard.hms.dbmi.avillach.hpds.test;
 
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.ResultType;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.*;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.v3.CountV3Processor;
 import edu.harvard.hms.dbmi.avillach.hpds.test.util.BuildIntegrationTestEnvironment;
 import org.junit.jupiter.api.BeforeAll;
@@ -9,8 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
@@ -25,10 +28,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableAutoConfiguration
 @SpringBootTest(classes = edu.harvard.hms.dbmi.avillach.hpds.service.HpdsApplication.class)
 @ActiveProfiles("integration-test")
+@AutoConfigureMockMvc
 public class CountV3ProcessorIntegrationTest {
 
     @Autowired
     private CountV3Processor countProcessor;
+
+    @MockitoBean
+    private UserRequestContext userRequestContext;
 
     @BeforeAll
     public static void beforeAll() {
@@ -122,9 +129,9 @@ public class CountV3ProcessorIntegrationTest {
     }
 
     /**
-     * With an OR clause the cohort is broader than any single filter's values, so a cross count reports each concept's full
-     * distribution across that cohort: SEX shows female (present via the OR'd POPULATION branch) alongside the called-out male, and
-     * POPULATION shows the populations of the OR'd males alongside the called-out Finnish.
+     * With an OR clause the cohort is broader than any single filter's values, so a cross count reports each concept's full distribution
+     * across that cohort: SEX shows female (present via the OR'd POPULATION branch) alongside the called-out male, and POPULATION shows the
+     * populations of the OR'd males alongside the called-out Finnish.
      */
     @Test
     public void runCategoryCrossCounts_twoFiltersOr_reportsFullCohortDistribution() {

--- a/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/QueryExecutorIntegrationTest.java
+++ b/service/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/test/QueryExecutorIntegrationTest.java
@@ -3,6 +3,7 @@ package edu.harvard.hms.dbmi.avillach.hpds.test;
 import com.google.common.collect.Sets;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.ResultType;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.*;
+import edu.harvard.hms.dbmi.avillach.hpds.processing.util.UserRequestContext;
 import edu.harvard.hms.dbmi.avillach.hpds.processing.v3.QueryExecutor;
 import edu.harvard.hms.dbmi.avillach.hpds.test.util.BuildIntegrationTestEnvironment;
 import org.junit.jupiter.api.BeforeAll;
@@ -12,9 +13,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.*;
 
@@ -24,12 +28,16 @@ import static org.junit.jupiter.api.Assertions.*;
 @EnableAutoConfiguration
 @SpringBootTest(classes = edu.harvard.hms.dbmi.avillach.hpds.service.HpdsApplication.class)
 @ActiveProfiles("integration-test")
+@AutoConfigureMockMvc
 public class QueryExecutorIntegrationTest {
 
     private static final Logger log = LoggerFactory.getLogger(QueryExecutorIntegrationTest.class);
 
     @Autowired
     private QueryExecutor queryExecutor;
+
+    @MockitoBean
+    private UserRequestContext userRequestContext;
 
     @BeforeAll
     public static void beforeAll() {


### PR DESCRIPTION
* Create `SummaryColumnMeta` to expose `ColumnMeta` fields that are relevant above the disk-access level.
* Add `UserRequestContext` to store user consents without passing them everywhere up and down the stack
* Create `PartitionedPhenotypicObservationStore` to manage partitioning of `PhenotypicObservationStore`
* Update various configuration of spring beans and configurations